### PR TITLE
fix axios post request

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,14 @@
 import './index.css'
 
+import axios from 'axios'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {BrowserRouter as Router} from 'react-router-dom'
 
 import {Webstrom} from './Webstrom'
+
+axios.defaults.xsrfCookieName = 'csrftoken'
+axios.defaults.xsrfHeaderName = 'X-CSRFToken'
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Pridal som do index.tsx nastavenia pre axios.

Teraz uz ma header prilozeny csrf token a teda post requesty funguju normalne. Malo by to aj vyriesit Matusov problem pri registracii.

Pri requestoch sa musi pouzivat relativna url /api/... a nie absolutna http://localhost:8000/...

Priklad:

```
axios.post('/api/user/login/', {
  email: 'webmaster@strom.sk',
  password: 'gumibanan',
})
.then(
  (response) => {
    console.log(response)
  },
  (error) => {
    console.log(error)
  },
)
```