### PR TITLE
Add email verification page

### DIFF
--- a/src/pages/Router/Router.tsx
+++ b/src/pages/Router/Router.tsx
@@ -6,6 +6,7 @@ import {PageLayout} from '../../components/PageLayout/PageLayout'
 import {Admin} from '../Admin/Admin'
 import {PagePlaceholder} from '../PagePlaceholder'
 import {Posts} from '../Post/Post'
+import {VerifyEmail} from '../VerifyEmail/VerifyEmail'
 
 export const Router: React.FC<{seminarId: number}> = ({seminarId}) => {
   return (
@@ -20,7 +21,8 @@ export const Router: React.FC<{seminarId: number}> = ({seminarId}) => {
             <Route path={'/matik/'} component={MatikRouter} />
             <Route path={'/malynar/'} component={MalynarRouter} />
             <Route path={'/zdruzenie/'} component={ZdruzenieRouter} />
-            <Route path={'/example/'} component={ExampleRouter}></Route>
+            <Route path={'/verify-email/:verificationKey'} component={VerifyEmail} />
+            <Route path={'/example/'} component={ExampleRouter} />
           </PageLayout>
         </Route>
       </Switch>

--- a/src/pages/VerifyEmail/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail/VerifyEmail.tsx
@@ -1,0 +1,30 @@
+import axios, {AxiosError} from 'axios'
+import React, {useEffect, useState} from 'react'
+import {useParams} from 'react-router-dom'
+
+interface IUseParam {
+  verificationKey: string
+}
+
+export const VerifyEmail: React.FC = () => {
+  const {verificationKey} = useParams<IUseParam>()
+  const [response, setResponse] = useState('')
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await axios.post('/api/user/registration/verify-email/', {key: verificationKey})
+        const response =
+          data.status === 200 ? 'Email successfully verified' : 'An unexpected response status code has occurred'
+        setResponse(response)
+      } catch (e) {
+        const ex = e as AxiosError
+        const error = ex.response?.status === 404 ? 'Wrong verification key' : 'An unexpected error has occurred'
+        setResponse(error)
+      }
+    }
+    fetchData()
+  }, [verificationKey])
+
+  return <>{response}</>
+}


### PR DESCRIPTION
Pridana cesta /verify-email/:verificationKey

verificationKey sa posle na /api/user/registration/verify-email. Mozne odpovede:

- 404: ak key nekoresponduje k ziadnemu emailu na overenie
- 200: ak sa email uspesne overil

Poznamka: zatial neexistuje v designe od Dorot miesto kde sa toto overovanie uskutocne alebo ako sa vyzerat odozva pre uzivatela, takze odpoved sa zatial len tak zobrazi ako string.