### PR TITLE
Admin - cele manazovanie Postov, listovanie Serii

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "mathjax-full": "^3.1.2",
     "mathjax-react": "^1.0.6",
     "node-sass": "4.14.1",
-    "ra-data-django-rest-framework": "^0.1.5",
     "react": "^16.13.1",
     "react-admin": "^3.11.3",
     "react-cookie": "^4.0.3",

--- a/src/admin/dataProvider.ts
+++ b/src/admin/dataProvider.ts
@@ -1,0 +1,154 @@
+import {stringify} from 'querystring'
+import {DataProvider, fetchUtils, Record as RARecord} from 'react-admin'
+import {Cookies} from 'react-cookie'
+
+// potencialne TODO: ak BE bude mat pagination, filter alebo sort, upravime a pouzijeme tento kod.
+// zatial je pagination aj sort rieseny client-side a len pre getList, filter/search nemame.
+
+// import {FilterPayload, PaginationPayload, SortPayload} from 'react-admin'
+
+// const getPaginationQuery = ({page, perPage}: PaginationPayload) => ({
+//   page,
+//   page_size: perPage,
+// })
+// const getFilterQuery = ({q, ...otherSearchParams}: FilterPayload) => ({
+//   ...otherSearchParams,
+//   search: q,
+// })
+// const getOrderingQuery = ({field, order}: SortPayload) => ({
+//   ordering: `${order === 'ASC' ? '' : '-'}${field}`,
+// })
+
+const cookies = new Cookies()
+
+const authFetchJson = (url: string, options?: Record<string, unknown>) => {
+  const token = cookies.get('webstrom-token')
+  const authOptions = token
+    ? {
+        user: {
+          authenticated: true,
+          token: 'Token ' + token,
+        },
+      }
+    : {}
+  return fetchUtils.fetchJson(url, Object.assign(authOptions, options))
+}
+
+const dynamicSort = (key: string, order: string) => {
+  const orderValue = order === 'ASC' ? 1 : -1
+  return (a: RARecord, b: RARecord) => {
+    // eslint-disable-next-line security/detect-object-injection
+    if (a[key] > b[key]) return orderValue
+    // eslint-disable-next-line security/detect-object-injection
+    if (a[key] < b[key]) return -orderValue
+    return 0
+  }
+}
+
+const apiUrl = '/api'
+
+// skopirovane a dost upravene z https://github.com/bmihelac/ra-data-django-rest-framework/blob/master/src/index.ts
+export const dataProvider: DataProvider = {
+  getList: async (resource, params) => {
+    const query = {
+      // TODO: ked BE bude mat pagination, filter alebo sort
+      // ...getFilterQuery(params.filter),
+      // ...getPaginationQuery(params.pagination),
+      // ...getOrderingQuery(params.sort),
+    }
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/?${stringify(query)}`)
+
+    // client-side sort
+    const {field, order} = params.sort
+    json.sort(dynamicSort(field, order))
+
+    // client-side pagination
+    const {page, perPage} = params.pagination
+    const pagedData = json.slice((page - 1) * perPage, page * perPage)
+
+    return {
+      data: pagedData,
+      total: json.length,
+    }
+  },
+  getOne: async (resource, params) => {
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/${params.id}/`)
+
+    return {
+      data: json,
+    }
+  },
+  getMany: async (resource, params) => {
+    const data = await Promise.all(params.ids.map((id) => authFetchJson(`${apiUrl}/${resource}/${id}/`)))
+
+    return {
+      data: data.map(({json}) => json),
+    }
+  },
+  // TODO: ak budeme pouzivat tuto funkciu, upravime podla getList (pagination, sort, filter). uprimne este neviem, pri com sa pouziva
+  getManyReference: async (resource, params) => {
+    const query = {
+      [params.target]: params.id,
+    }
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/?${stringify(query)}`)
+
+    return {
+      data: json,
+      total: json.length,
+    }
+  },
+  update: async (resource, params) => {
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/${params.id}/`, {
+      method: 'PATCH',
+      body: JSON.stringify(params.data),
+    })
+
+    return {data: json}
+  },
+  updateMany: async (resource, params) => {
+    const data = await Promise.all(
+      params.ids.map((id) =>
+        authFetchJson(`${apiUrl}/${resource}/${id}/`, {
+          method: 'PATCH',
+          body: JSON.stringify(params.data),
+        }),
+      ),
+    )
+
+    return {
+      data: data.map(({json}) => json),
+    }
+  },
+  create: async (resource, params) => {
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/`, {
+      method: 'POST',
+      body: JSON.stringify(params.data),
+    })
+
+    return {
+      data: json,
+    }
+  },
+  delete: async (resource, params) => {
+    const {json} = await authFetchJson(`${apiUrl}/${resource}/${params.id}/`, {
+      method: 'DELETE',
+    })
+
+    return {
+      data: json,
+    }
+  },
+  deleteMany: async (resource, params) => {
+    const data = await Promise.all(
+      params.ids.map((id) =>
+        authFetchJson(`${apiUrl}/${resource}/${id}/`, {
+          method: 'DELETE',
+        }),
+      ),
+    )
+
+    return {
+      data: data.map(({json}) => json.id),
+    }
+  },
+}

--- a/src/admin/tokenAuthProvider.ts
+++ b/src/admin/tokenAuthProvider.ts
@@ -1,0 +1,43 @@
+import {AuthProvider} from 'react-admin'
+import {Cookies} from 'react-cookie'
+
+const authTokenUrl = '/api/user/login/'
+const cookies = new Cookies()
+
+export const authProvider: AuthProvider = {
+  login: async ({username, password}) => {
+    const response = await fetch(authTokenUrl, {
+      method: 'POST',
+      body: JSON.stringify({email: username, password}),
+      headers: new Headers({'Content-Type': 'application/json'}),
+    })
+    if (response.ok) {
+      cookies.set('webstrom-token', (await response.json()).key)
+      return
+    }
+    if (response.headers.get('content-type') !== 'application/json') {
+      throw new Error(response.statusText)
+    }
+
+    const json = await response.json()
+    const error = json.non_field_errors
+    throw new Error(error || response.statusText)
+  },
+  logout: () => {
+    cookies.remove('webstrom-token')
+    return Promise.resolve()
+  },
+  checkAuth: () =>
+    cookies.get('webstrom-token') ? Promise.resolve() : Promise.reject(new Error('webstrom-token cookie is missing')),
+  checkError: (error) => {
+    const status = error.status
+    if (status === 401 || status === 403) {
+      cookies.remove('webstrom-token')
+      return Promise.reject(new Error(`request status ${status}`))
+    }
+    return Promise.resolve()
+  },
+  getPermissions: () => {
+    return Promise.resolve()
+  },
+}

--- a/src/admin/tokenAuthProvider.ts
+++ b/src/admin/tokenAuthProvider.ts
@@ -1,4 +1,4 @@
-import {AuthProvider} from 'react-admin'
+import {AuthProvider, HttpError} from 'react-admin'
 import {Cookies} from 'react-cookie'
 
 const authTokenUrl = '/api/user/login/'
@@ -28,12 +28,14 @@ export const authProvider: AuthProvider = {
     return Promise.resolve()
   },
   checkAuth: () =>
-    cookies.get('webstrom-token') ? Promise.resolve() : Promise.reject(new Error('webstrom-token cookie is missing')),
+    cookies.get('webstrom-token')
+      ? Promise.resolve()
+      : Promise.reject(new HttpError('checkAuth: webstrom-token cookie is missing', 401)),
   checkError: (error) => {
     const status = error.status
     if (status === 401 || status === 403) {
       cookies.remove('webstrom-token')
-      return Promise.reject(new Error(`request status ${status}`))
+      return Promise.reject(new HttpError(`checkError: unauthorized/forbidden request`, status))
     }
     return Promise.resolve()
   },

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -1,12 +1,24 @@
-import drfProvider from 'ra-data-django-rest-framework'
+// eslint-disable-next-line node/no-extraneous-import
+import {createBrowserHistory} from 'history'
 import React, {FC} from 'react'
-import {Admin as ReactAdmin} from 'react-admin'
-import {useHistory} from 'react-router-dom'
+import {Admin as ReactAdmin, Resource} from 'react-admin'
 
-const dataProvider = drfProvider('/api')
+import {dataProvider} from '../../admin/dataProvider'
+import {authProvider} from '../../admin/tokenAuthProvider'
+import {CompetitionList} from './Competition/CompetitionList'
+import {PostCreate} from './Post/PostCreate'
+import {PostEdit} from './Post/PostEdit'
+import {PostList} from './Post/PostList'
+import {PostShow} from './Post/PostShow'
 
-export const Admin: FC = () => {
-  // needed to get of console warning (react admin actually uses react-router as well, so we need to link the instances this way)
-  const history = useHistory()
-  return <ReactAdmin dataProvider={dataProvider} history={history} />
-}
+// react admin interne pouziva react-router, takze treba takto spojit ich instancie, inak to hadze warningy a routovanie nefunguje uplne spravne.
+// pri prechode na next.js to myslim budeme vediet vyhodit a pouzivat defaultnu hash historiu
+const history = createBrowserHistory({basename: '/admin'})
+
+export const Admin: FC = () => (
+  <ReactAdmin authProvider={authProvider} dataProvider={dataProvider} history={history}>
+    <Resource name="cms/post" list={PostList} edit={PostEdit} show={PostShow} create={PostCreate} />
+    {/* TODO: create, edit, celkovo rozumne rozhranie pre sutaze/serie */}
+    <Resource name="competition/series" list={CompetitionList} />
+  </ReactAdmin>
+)

--- a/src/pages/Admin/Competition/CompetitionList.tsx
+++ b/src/pages/Admin/Competition/CompetitionList.tsx
@@ -1,0 +1,20 @@
+import React, {FC} from 'react'
+import {ArrayField, Datagrid, DateField, List, ListProps, TextField} from 'react-admin'
+
+// TODO: premysliet a prerobit rozhranie, mozno ako u postov - pri kliku na riadok ukazat Show, kde budu priklady
+// (nie ako teraz v zanorenom Datagride)
+export const CompetitionList: FC<ListProps> = (props) => (
+  <List {...props}>
+    <Datagrid>
+      <TextField source="id" />
+      <DateField source="deadline" />
+      <TextField source="order" />
+      <ArrayField source="problems">
+        <Datagrid>
+          <TextField source="id" />
+          <TextField source="text" />
+        </Datagrid>
+      </ArrayField>
+    </Datagrid>
+  </List>
+)

--- a/src/pages/Admin/Post/PostCreate.tsx
+++ b/src/pages/Admin/Post/PostCreate.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react'
+import {ArrayInput, Create, CreateProps, DateInput, SimpleForm, SimpleFormIterator, TextInput} from 'react-admin'
+
+// TODO: treba zistit, ako ma vyzerat tento PUT request a teda form, potom otestovat
+export const PostCreate: FC<CreateProps> = (props) => (
+  <Create {...props}>
+    <SimpleForm>
+      {/* <NumberInput source="id" fullWidth /> */}
+      <TextInput source="caption" fullWidth />
+      <TextInput source="short_text" fullWidth />
+      <TextInput source="details" fullWidth />
+      <DateInput source="added_at" fullWidth />
+      <DateInput source="show_after" fullWidth />
+      <DateInput source="disable_after" fullWidth />
+      <ArrayInput source="links">
+        <SimpleFormIterator>
+          {/* <NumberInput source="id" fullWidth /> */}
+          <TextInput source="caption" fullWidth />
+          <TextInput source="url" fullWidth />
+        </SimpleFormIterator>
+      </ArrayInput>
+    </SimpleForm>
+  </Create>
+)

--- a/src/pages/Admin/Post/PostEdit.tsx
+++ b/src/pages/Admin/Post/PostEdit.tsx
@@ -1,0 +1,48 @@
+import React, {FC} from 'react'
+import {
+  ArrayInput,
+  DateInput,
+  Edit,
+  EditActionsProps,
+  EditProps,
+  FormTab,
+  ListButton,
+  NumberInput,
+  ShowButton,
+  SimpleFormIterator,
+  TabbedForm,
+  TextInput,
+  TopToolbar,
+} from 'react-admin'
+
+const PostEditActions: FC<EditActionsProps> = ({basePath, data}) => (
+  <TopToolbar>
+    <ShowButton basePath={basePath} record={data} />
+    <ListButton basePath={basePath} record={data} />
+  </TopToolbar>
+)
+
+export const PostEdit: FC<EditProps> = (props) => (
+  <Edit {...props} actions={<PostEditActions />}>
+    <TabbedForm>
+      <FormTab label="general">
+        <NumberInput source="id" fullWidth />
+        <TextInput source="caption" fullWidth />
+        <TextInput source="short_text" fullWidth />
+        <TextInput source="details" fullWidth />
+        <DateInput source="added_at" fullWidth />
+        <DateInput source="show_after" fullWidth />
+        <DateInput source="disable_after" fullWidth />
+      </FormTab>
+      <FormTab label="links">
+        <ArrayInput source="links">
+          <SimpleFormIterator>
+            <NumberInput source="id" fullWidth />
+            <TextInput source="caption" fullWidth />
+            <TextInput source="url" fullWidth />
+          </SimpleFormIterator>
+        </ArrayInput>
+      </FormTab>
+    </TabbedForm>
+  </Edit>
+)

--- a/src/pages/Admin/Post/PostList.tsx
+++ b/src/pages/Admin/Post/PostList.tsx
@@ -1,0 +1,18 @@
+import React, {FC} from 'react'
+import {Datagrid, DateField, List, ListProps, NumberField, TextField} from 'react-admin'
+
+export const PostList: FC<ListProps> = (props) => (
+  <List {...props}>
+    <Datagrid rowClick="show">
+      <NumberField source="id" />
+      <TextField source="caption" />
+      <TextField source="short_text" />
+      <TextField source="details" />
+      <DateField source="added_at" />
+      <DateField source="show_after" />
+      <DateField source="disable_after" />
+      {/* <ArrayField source="links" /> */}
+      {/* <ArrayField source="sites" /> */}
+    </Datagrid>
+  </List>
+)

--- a/src/pages/Admin/Post/PostShow.tsx
+++ b/src/pages/Admin/Post/PostShow.tsx
@@ -1,0 +1,54 @@
+import React, {FC} from 'react'
+import {
+  ArrayField,
+  Datagrid,
+  DateField,
+  EditButton,
+  ListButton,
+  NumberField,
+  Show,
+  ShowActionsProps,
+  ShowProps,
+  SimpleShowLayout,
+  Tab,
+  TabbedShowLayout,
+  TextField,
+  TopToolbar,
+} from 'react-admin'
+
+const PostShowActions: FC<ShowActionsProps> = ({basePath, data}) => (
+  <TopToolbar>
+    <EditButton basePath={basePath} record={data} />
+    <ListButton basePath={basePath} record={data} />
+  </TopToolbar>
+)
+
+export const PostShow: FC<ShowProps> = (props) => (
+  <Show {...props} actions={<PostShowActions />}>
+    <TabbedShowLayout>
+      <Tab label="general">
+        <SimpleShowLayout>
+          <NumberField source="id" />
+          <TextField source="caption" />
+          <TextField source="short_text" />
+          <TextField source="details" />
+          <DateField source="added_at" />
+          <DateField source="show_after" />
+          <DateField source="disable_after" />
+          {/* <ArrayField source="sites" /> */}
+        </SimpleShowLayout>
+      </Tab>
+      <Tab label="links">
+        <SimpleShowLayout>
+          <ArrayField source="links">
+            <Datagrid>
+              <NumberField source="id" />
+              <TextField source="caption" />
+              <TextField source="url" />
+            </Datagrid>
+          </ArrayField>
+        </SimpleShowLayout>
+      </Tab>
+    </TabbedShowLayout>
+  </Show>
+)

--- a/src/pages/Router/Router.tsx
+++ b/src/pages/Router/Router.tsx
@@ -13,7 +13,7 @@ export const Router: React.FC<{seminarId: number}> = ({seminarId}) => {
   return (
     <div id="main-content">
       <Switch>
-        <Route path={'/admin'} component={AdminRouter} />
+        <Route path={'/admin'} component={Admin} />
         {/* aby sme mohli pouzit PageLayout len pre niektore stranky (vsetky okrem admina), musi to byt takto zabalene
           vo vlastnej Route, ktora vie, ktore stranky matchuje (a potom hlada hlbsie dalsie Routes) */}
         <Route path={['/strom/', '/matik/', '/malynar/', '/zdruzenie/', '/']}>
@@ -133,17 +133,6 @@ const ZdruzenieRouter: React.FC = () => {
       </Route>
       <Route exact path={path + 'register/'}>
         <RegisterForm />
-      </Route>
-    </>
-  )
-}
-
-const AdminRouter: React.FC = () => {
-  const {path} = useRouteMatch()
-  return (
-    <>
-      <Route exact path={path}>
-        <Admin />
       </Route>
     </>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -10412,15 +10412,6 @@ query-string@^5.1.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.12.1:
-  version "6.13.8"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.8.tgz#8cf231759c85484da3cf05a851810d8e825c1159"
-  integrity sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10450,13 +10441,6 @@ ra-core@^3.11.3:
     prop-types "^15.6.1"
     query-string "^5.1.1"
     reselect "~3.0.0"
-
-ra-data-django-rest-framework@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/ra-data-django-rest-framework/-/ra-data-django-rest-framework-0.1.5.tgz#5d754124511d1f2353557f514886ae51427a6211"
-  integrity sha512-qeSpzpZL5aN1+fJtiRnTQragZ+FkZ6CKhkmT8PXikBtvHNK1qhKW1sqCNY6y7EFAoWVFU3uk7FxZYXpVOJjRxw==
-  dependencies:
-    query-string "^6.12.1"
 
 ra-i18n-polyglot@^3.11.3:
   version "3.11.3"
@@ -11867,11 +11851,6 @@ speech-rule-engine@^3.1.1:
     wicked-good-xpath "^1.3.0"
     xmldom-sre "^0.1.31"
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11991,11 +11970,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Ako pisem v komentaroch, v podstate som vzal https://github.com/bmihelac/ra-data-django-rest-framework a prepisal pre nase ucely (napriklad v ich auth provideri sa pouziva local storage na ukladanie tokenu, a my uz vieme, ze to chceme mat v cookies -> hned prvy dovod napisat si providerov sami).

React Admin potrebuje dve zakladne veci - `dataProvider` a `authProvider`. Tak tieto mame uz napisane, aj ked mozno casom budeme robit nejake zmeny, ak budeme mat komplikovanejsie poziadavky.

Potom sa uz len definuje `Resource` a struktura rozhrania v Create/Edit/Show/List. Tieto vsetky som spravil pre Posty (`cms/post`) a len list pre `competition/series`.

PATCH a PUT requesty este nefunguju. Bud je chyba na strane BE, alebo nam musia dat lepsie info, ako tie requesty strukturovat. Rovnako bude treba domysliet formy pre tieto Create/Edit - napriklad schovat alebo disablenut ID input a tak (pri Create som IDs zatial schoval).

Nejake screeny:
![image](https://user-images.githubusercontent.com/6044119/123074769-e702f880-d417-11eb-8ca3-2afd4287eed1.png)
![image](https://user-images.githubusercontent.com/6044119/123074826-f1bd8d80-d417-11eb-81e8-f2e5407a09f0.png)
![image](https://user-images.githubusercontent.com/6044119/123074880-000ba980-d418-11eb-9346-5b2a1a1b4031.png)
![image](https://user-images.githubusercontent.com/6044119/123074934-0ac63e80-d418-11eb-83ea-9d284ae6874b.png)
![image](https://user-images.githubusercontent.com/6044119/123075000-187bc400-d418-11eb-9e91-09ad9e217cf7.png)
