### PR TITLE
Generovane API typy

### DIFF
--- a/src/types/api/generated/base.ts
+++ b/src/types/api/generated/base.ts
@@ -1,0 +1,10 @@
+export interface FlatPage {
+  id?: number
+  url: string
+  title: string
+  content?: string
+  enable_comments?: boolean
+  template_name?: string
+  registration_required?: boolean
+  sites: any[]
+}

--- a/src/types/api/generated/cms.ts
+++ b/src/types/api/generated/cms.ts
@@ -1,0 +1,23 @@
+export interface MenuItemShort {
+  id?: number
+  caption: string
+  url: string
+}
+
+export interface PostLink {
+  id?: number
+  caption: string
+  url: string
+}
+
+export interface Post {
+  id?: number
+  links: PostLink[]
+  caption: string
+  short_text: string
+  details?: string
+  added_at?: string
+  show_after: string
+  disable_after: string
+  sites: any[]
+}

--- a/src/types/api/generated/competition.ts
+++ b/src/types/api/generated/competition.ts
@@ -1,0 +1,144 @@
+export interface UnspecifiedPublication {
+  id?: number
+  name?: string
+  file: any
+  event?: any | null
+}
+
+export interface SemesterPublication {
+  id?: number
+  name?: string
+  order: number
+  file: any
+  thumbnail?: any
+  semester?: any | null
+}
+
+export interface RegistrationLink {
+  id?: number
+  url: string
+  start: string
+  end: string
+  additional_info: string
+  event: any
+}
+
+export interface Event {
+  id?: number
+  unspecifiedpublication_set: UnspecifiedPublication[]
+  registration_links: RegistrationLink[]
+  year?: number
+  school_year?: string
+  start: string
+  end: string
+  competition?: any | null
+}
+
+export interface Competition {
+  id?: number
+  event_set: Event[]
+  name: string
+  start_year?: number
+  description?: string
+  rules?: string | null
+  competition_type: any
+  min_years_until_graduation?: number | null
+  sites: any[]
+  permission_group?: any[]
+}
+
+export interface EventRegistration {
+  school: any
+  grade?: any
+  profile: any
+}
+
+export interface Problem {
+  id?: number
+  text: string
+  order: number
+  series?: any
+}
+
+export interface Comment {
+  id?: number
+  text: string
+  posted_at?: string
+  published: boolean
+  problem: any
+  posted_by: any
+}
+
+export interface Solution {
+  id?: number
+  solution?: any
+  corrected_solution?: any
+  score?: number | null
+  vote?: any
+  uploaded_at?: string
+  is_online?: boolean
+  problem: any
+  semester_registration: any
+  late_tag?: any | null
+}
+
+export interface Series {
+  id?: number
+  order: number
+  deadline: string
+  complete: boolean
+  frozen_results?: string | null
+  semester: any
+}
+
+export interface SeriesWithProblems {
+  id?: number
+  problems: Problem[]
+  order: number
+  deadline: string
+  complete: boolean
+  frozen_results?: string | null
+  semester?: any
+}
+
+export interface Semester {
+  id?: number
+  series_set: Series[]
+  year?: number
+  school_year?: string
+  start: string
+  end: string
+  season_code: any
+  frozen_results?: string | null
+  competition?: any | null
+  late_tags?: any[]
+}
+
+export interface SemesterWithProblems {
+  id?: number
+  series_set: SeriesWithProblems[]
+  semesterpublication_set: SemesterPublication[]
+  unspecifiedpublication_set: UnspecifiedPublication[]
+  year?: number
+  school_year?: string
+  start: string
+  end: string
+  season_code: any
+  frozen_results?: string | null
+  competition?: any | null
+  late_tags?: any[]
+}
+
+export interface LateTag {
+  id?: number
+  name: string
+  slug: string
+  upper_bound: string
+}
+
+export interface Grade {
+  id?: number
+  name: string
+  tag: string
+  years_until_graduation: number
+}

--- a/src/types/api/generated/personal.ts
+++ b/src/types/api/generated/personal.ts
@@ -1,0 +1,66 @@
+export interface County {
+  code?: number
+  name: string
+}
+
+export interface District {
+  code?: number
+  name: string
+  abbreviation: string
+  county: any
+}
+
+export interface School {
+  code?: number
+  name: string
+  abbreviation: string
+  street: string
+  city: string
+  zip_code: string
+  email?: string
+  district: any
+}
+
+export interface SchoolShort {
+  code?: number
+  name: string
+  abbreviation: string
+  street: string
+  city: string
+  zip_code: string
+}
+
+export interface Profile {
+  first_name?: string
+  last_name?: string
+  nickname?: string
+  school: any
+  phone?: string
+  parent_phone?: string
+  gdpr?: boolean
+  grade: number
+}
+
+export interface ProfileCreate {
+  first_name: string
+  last_name: string
+  nickname?: string
+  school: any
+  phone?: string
+  parent_phone?: string
+  gdpr?: boolean
+  grade: number
+}
+
+export interface ProfileShort {
+  first_name: string
+  last_name: string
+  nickname?: string
+}
+
+export interface ProfileMail {
+  first_name: string
+  last_name: string
+  nickname?: string
+  email: string
+}

--- a/src/types/api/generated/problem_database.ts
+++ b/src/types/api/generated/problem_database.ts
@@ -1,0 +1,65 @@
+export interface Seminar {
+  id?: number
+  name: string
+}
+
+export interface ActivityType {
+  id?: number
+  name: string
+  seminar?: any
+}
+
+export interface Activity {
+  id?: number
+  date: string
+  description: string
+  soft_deleted?: boolean
+  activity_type?: any
+}
+
+export interface Difficulty {
+  id?: number
+  name: string
+  activity_type?: any
+}
+
+export interface Problem {
+  id?: number
+  problem: string
+  result: string
+  solution: string
+  soft_deleted?: boolean
+  problem_type: any[]
+}
+
+export interface Media {
+  id?: number
+  data: any
+  soft_deleted?: boolean
+  problem?: any
+}
+
+export interface ProblemActivity {
+  id?: number
+  problem?: any
+  activity?: any
+  difficulty?: any
+}
+
+export interface ProblemType {
+  id?: number
+  name: string
+  description: string
+  seminar?: any
+}
+
+export interface Tag {
+  id?: number
+  name: string
+}
+
+export interface ProblemTag {
+  id?: number
+  problem?: any
+  tag?: any
+}

--- a/src/types/api/generated/user.ts
+++ b/src/types/api/generated/user.ts
@@ -1,0 +1,36 @@
+export interface Login {
+  email?: string
+  password: string
+}
+
+export interface Token {
+  key: string
+}
+
+export interface UserDetails {
+  pk?: number
+  email?: string
+  profile: any
+}
+
+export interface Register {
+  email: string
+  password1: string
+  password2: string
+  profile: any
+  new_school_description: string
+}
+
+export interface VerifyEmail {
+  key: string
+}
+
+export interface PasswordChange {
+  old_password: string
+  new_password1: string
+  new_password2: string
+}
+
+export interface UserShort {
+  email: string
+}


### PR DESCRIPTION
typy generovane z BE cez `django-typomatic` (BE PR: https://github.com/ZdruzenieSTROM/webstrom-backend/pull/101).
kazdy subor som preulozil, nech ho ESLint sformatuje.

kazdopadne... este som nemenil nas kod, aby tieto typy pouzival, nie su az take strong (je tam vela `any`, kde by som cakal `number`, atd.), a nechce sa mi tomu venovat, ked mam ine veci este na praci. Takze je tu novy task pre niekoho:
- zistit, preco tam django typomatic dava `any`, pozriet sa na BE alebo sa spytat chalanov, co je na tych fieldoch specialne, co realne mozeme pod tymi properties cakat, a potom to rucne prepisat.
- niektore fieldy su optional (otaznicek pri `id?` a `year?` atd.) - treba zistit preco a ci s nimi mozeme ratat, ze tam vzdy su, alebo nie.

ked budeme mat tie typy fajn, mozeme prepisovat kod aby ich pouzival. zatial som ich dal do osobitneho priecinka `generated/`