### PR TITLE
Upgrade reactu na v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "mathjax-react": "^1.0.6",
     "next": "11.0.1",
     "node-sass": "4.14.1",
-    "react": "^16.13.1",
+    "react": "^17.0.2",
     "react-admin": "^3.11.3",
     "react-cookie": "^4.0.3",
-    "react-dom": "^16.13.1",
+    "react-dom": "^17.0.2",
     "react-hook-form": "^6.12.1",
     "react-icons": "^3.11.0",
     "typescript": "^4.3.4"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,7 +16,7 @@ import '../src/components/PageLayout/components/MenuMain.css'
 import axios, {AxiosError} from 'axios'
 import {AppProps} from 'next/app'
 import Head from 'next/head'
-import React, {FC, useEffect} from 'react'
+import {FC, useEffect} from 'react'
 import {Cookies, useCookies} from 'react-cookie'
 
 const cookies = new Cookies()

--- a/src/components/FormItems/FormCheckbox/FormCheckbox.tsx
+++ b/src/components/FormItems/FormCheckbox/FormCheckbox.tsx
@@ -1,5 +1,5 @@
 import {Checkbox, CheckboxProps, FormControlLabel} from '@material-ui/core'
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {Control, Controller} from 'react-hook-form'
 
 export const FormCheckbox: FC<CheckboxProps & {name: string; control: Control; label: string}> = ({

--- a/src/components/FormItems/FormInput/FormInput.tsx
+++ b/src/components/FormItems/FormInput/FormInput.tsx
@@ -1,5 +1,5 @@
 import {FormControl, Input, InputLabel, InputProps} from '@material-ui/core'
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {Control, Controller} from 'react-hook-form'
 
 export const FormInput: FC<InputProps & {name: string; control: Control; label: string}> = ({control, name, label}) => (

--- a/src/components/FormItems/FormSelect/FormSelect.tsx
+++ b/src/components/FormItems/FormSelect/FormSelect.tsx
@@ -1,5 +1,5 @@
 import {FormControl, InputLabel, MenuItem, Select, SelectProps} from '@material-ui/core'
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {Control, Controller} from 'react-hook-form'
 
 export type SelectOption = {id: number; label: string}

--- a/src/components/Latex/Latex.tsx
+++ b/src/components/Latex/Latex.tsx
@@ -1,6 +1,6 @@
 // import './Latex.css'
 import {MathComponent} from 'mathjax-react'
-import React from 'react'
+import {FC} from 'react'
 
 // toto je regex, ktory matchuje LaTeX matematiku: $$.$$ \[.\] $.$ \(.\)
 const re = /((?<!(\\|\$))\$(?!\$).+?(?<!(\\|\$))\$(?!\$))|(\$\$.+?\$\$)|(\\\[.+?\\\])|(\\\(.+?\\\))/gsu
@@ -13,7 +13,7 @@ const trim = (str: string) => {
   }
 }
 
-export const Latex: React.FC<{children: string}> = ({children}) => {
+export const Latex: FC<{children: string}> = ({children}) => {
   const matches = Array.from(children.matchAll(re))
 
   if (matches.length === 0) {

--- a/src/components/Latex/LatexExample.tsx
+++ b/src/components/Latex/LatexExample.tsx
@@ -1,11 +1,11 @@
 // import './LatexExample.css'
-import React, {useState} from 'react'
+import {ChangeEvent, FC, useState} from 'react'
 
 import {Latex} from './Latex'
 
-export const LatexExample: React.FC = () => {
+export const LatexExample: FC = () => {
   const [tex, setTex] = useState('')
-  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setTex(event.target.value)
   }
 

--- a/src/components/Marquee/Marquee.tsx
+++ b/src/components/Marquee/Marquee.tsx
@@ -1,5 +1,5 @@
 // import './Marquee.scss'
-import React, {useEffect, useRef, useState} from 'react'
+import {FC, useEffect, useRef, useState} from 'react'
 
 interface MarqueeProps {
   /**
@@ -77,7 +77,7 @@ interface MarqueeProps {
 }
 
 // tento komponent je z https://github.com/justin-chu/react-fast-marquee/blob/master/src/components/Marquee.tsx
-export const Marquee: React.FC<MarqueeProps> = ({
+export const Marquee: FC<MarqueeProps> = ({
   style = {},
   className = '',
   play = true,

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -1,13 +1,13 @@
 // import './Overlay.scss'
-import React from 'react'
+import {FC, MouseEvent} from 'react'
 
 interface IOverlay {
   display: boolean
   closeOverlay: () => void
 }
 
-export const Overlay: React.FC<IOverlay> = ({children, display, closeOverlay}) => {
-  const handleClick = (e: React.MouseEvent) => {
+export const Overlay: FC<IOverlay> = ({children, display, closeOverlay}) => {
+  const handleClick = (e: MouseEvent) => {
     // Po kliknutí na overlay, mimo akýchkoľvek iných elementov, sa overlay zatvorí.
     if ((e.target as Element).classList.contains('overlay')) {
       closeOverlay()

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 
 import {ScrollingText} from '../ScrollingText/ScrollingText'
 import {Footer} from './components/Footer'

--- a/src/components/PageLayout/components/Authentication.tsx
+++ b/src/components/PageLayout/components/Authentication.tsx
@@ -26,10 +26,6 @@ export const Authentication: FC = () => {
     setDisplayAuthenticationOverlay(false)
   }
 
-  const toggleDisplayLogin = () => {
-    setDisplayLogin((prevDisplay) => !prevDisplay)
-  }
-
   const displayLoginForm = () => {
     setDisplayAuthenticationOverlay(true)
     setDisplayLogin(true)
@@ -93,10 +89,7 @@ export const Authentication: FC = () => {
             </div>
             <div className="content">
               {displayLogin ? (
-                <LoginForm
-                  closeOverlay={toggleDisplayAuthenticationOverlay}
-                  loginRegistrationToggle={toggleDisplayLogin}
-                />
+                <LoginForm closeOverlay={toggleDisplayAuthenticationOverlay} />
               ) : (
                 '<RegistrationForm />' // Tu by mal byť registračný form od Matúša
               )}

--- a/src/components/PageLayout/components/Authentication.tsx
+++ b/src/components/PageLayout/components/Authentication.tsx
@@ -1,12 +1,12 @@
 // import './Authentication.scss'
 import axios, {AxiosError} from 'axios'
-import React, {useState} from 'react'
+import {FC, useState} from 'react'
 import {useCookies} from 'react-cookie'
 
 import {Overlay} from '../../Overlay/Overlay'
 import {LoginForm} from './LoginForm'
 
-export const Authentication: React.FC = () => {
+export const Authentication: FC = () => {
   const [displayAuthenticationOverlay, setDisplayAuthenticationOverlay] = useState(false)
   const [displayLogin, setDisplayLogin] = useState(true) // true -> zobrazí sa login, false -> zobrazí sa registrácia
   const [cookies, setCookie, removeCookie] = useCookies(['webstrom-token'])

--- a/src/components/PageLayout/components/Footer.tsx
+++ b/src/components/PageLayout/components/Footer.tsx
@@ -1,8 +1,8 @@
 // import './Footer.css'
-import React from 'react'
+import {FC} from 'react'
 import {useCookies} from 'react-cookie'
 
-export const Footer: React.FC = () => {
+export const Footer: FC = () => {
   const [cookies] = useCookies(['webstrom-token', 'webstrom-name'])
 
   return (

--- a/src/components/PageLayout/components/LoginForm.tsx
+++ b/src/components/PageLayout/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 // import './LoginForm.scss'
 import axios from 'axios'
-import React, {useEffect, useRef, useState} from 'react'
+import {FC, FormEvent, SyntheticEvent, useEffect, useRef, useState} from 'react'
 import {useCookies} from 'react-cookie'
 
 interface ILoginForm {
@@ -8,7 +8,7 @@ interface ILoginForm {
   loginRegistrationToggle: () => void
 }
 
-export const LoginForm: React.FC<ILoginForm> = ({closeOverlay, loginRegistrationToggle}) => {
+export const LoginForm: FC<ILoginForm> = ({closeOverlay, loginRegistrationToggle}) => {
   const [formData, setFormData] = useState({email: '', password: ''})
   const [, setCookie] = useCookies(['webstrom-token'])
   const emailRef = useRef<HTMLInputElement>(null)
@@ -17,12 +17,12 @@ export const LoginForm: React.FC<ILoginForm> = ({closeOverlay, loginRegistration
     emailRef.current?.focus()
   }, [])
 
-  const handleChange = (e: React.FormEvent<HTMLInputElement>) => {
+  const handleChange = (e: FormEvent<HTMLInputElement>) => {
     const {name, value} = e.currentTarget
     setFormData((prevData) => ({...prevData, [name]: value}))
   }
 
-  const handleLogin = async (event: React.SyntheticEvent) => {
+  const handleLogin = async (event: SyntheticEvent) => {
     event.preventDefault()
 
     try {

--- a/src/components/PageLayout/components/LoginForm.tsx
+++ b/src/components/PageLayout/components/LoginForm.tsx
@@ -1,14 +1,13 @@
 // import './LoginForm.scss'
-import axios from 'axios'
+import axios, {AxiosError} from 'axios'
 import {FC, FormEvent, SyntheticEvent, useEffect, useRef, useState} from 'react'
 import {useCookies} from 'react-cookie'
 
 interface ILoginForm {
   closeOverlay: () => void
-  loginRegistrationToggle: () => void
 }
 
-export const LoginForm: FC<ILoginForm> = ({closeOverlay, loginRegistrationToggle}) => {
+export const LoginForm: FC<ILoginForm> = ({closeOverlay}) => {
   const [formData, setFormData] = useState({email: '', password: ''})
   const [, setCookie] = useCookies(['webstrom-token'])
   const emailRef = useRef<HTMLInputElement>(null)
@@ -36,8 +35,9 @@ export const LoginForm: FC<ILoginForm> = ({closeOverlay, loginRegistrationToggle
       setCookie('webstrom-name', responseDetails.data['first_name'], {path: '/', expires: expirationDate})
 
       closeOverlay()
-    } catch (error) {
-      if (error.response.status === 400) {
+    } catch (e: unknown) {
+      const error = e as AxiosError
+      if (error.response?.status === 400) {
         console.log('Neplatné prihlasovacie údaje')
       }
     }

--- a/src/components/PageLayout/components/MenuMain.tsx
+++ b/src/components/PageLayout/components/MenuMain.tsx
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
-import React, {useEffect, useState} from 'react'
+import {FC, useEffect, useState} from 'react'
 import * as CgIcons from 'react-icons/cg'
 import * as FaIcons from 'react-icons/fa'
 
@@ -14,7 +14,7 @@ interface MenuItemInterface {
   url: string
 }
 
-export const MenuMain: React.FC<{seminarId: number}> = ({seminarId}) => {
+export const MenuMain: FC<{seminarId: number}> = ({seminarId}) => {
   const [isVisible, setIsVisible] = useState(true)
   const [menuItems, setMenuItems] = useState<MenuItemInterface[]>([])
 
@@ -70,7 +70,7 @@ export const MenuMain: React.FC<{seminarId: number}> = ({seminarId}) => {
   )
 }
 
-const MenuMainItem: React.FC<{caption: string; url: string}> = ({caption, url}) => {
+const MenuMainItem: FC<{caption: string; url: string}> = ({caption, url}) => {
   const router = useRouter()
   return (
     <div className={router.pathname === url ? 'menu-main-item active' : 'menu-main-item'}>

--- a/src/components/PageLayout/components/MenuSeminars.tsx
+++ b/src/components/PageLayout/components/MenuSeminars.tsx
@@ -1,8 +1,8 @@
 // import './MenuSeminars.css'
 import Link from 'next/link'
-import React from 'react'
+import {FC} from 'react'
 
-export const MenuSeminars: React.FC<{seminarId: number}> = ({seminarId}) => {
+export const MenuSeminars: FC<{seminarId: number}> = ({seminarId}) => {
   return (
     <div id="menu-seminars">
       <div className={seminarId === 3 ? 'menu-seminars-item active' : 'menu-seminars-item'}>

--- a/src/components/ScrollingText/ScrollingText.tsx
+++ b/src/components/ScrollingText/ScrollingText.tsx
@@ -1,9 +1,9 @@
 // import './ScrollingText.scss'
-import React from 'react'
+import {FC} from 'react'
 
 import {Marquee} from '../Marquee/Marquee'
 
-export const ScrollingText: React.FC = () => {
+export const ScrollingText: FC = () => {
   // text sa bude nacitavat z API ked bude vytvoreny endpoint na to
   const text =
     'Matboj sa uskutoční 15. októbra 2021 - Matboj sa uskutoční 15. októbra 2021 - Matboj sa uskutoční 15. októbra 2021'

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {Admin as ReactAdmin, Resource} from 'react-admin'
 
 import {dataProvider} from '../../admin/dataProvider'

--- a/src/pages/Admin/Competition/CompetitionList.tsx
+++ b/src/pages/Admin/Competition/CompetitionList.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {ArrayField, Datagrid, DateField, List, ListProps, TextField} from 'react-admin'
 
 // TODO: premysliet a prerobit rozhranie, mozno ako u postov - pri kliku na riadok ukazat Show, kde budu priklady

--- a/src/pages/Admin/Post/PostCreate.tsx
+++ b/src/pages/Admin/Post/PostCreate.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {ArrayInput, Create, CreateProps, DateInput, SimpleForm, SimpleFormIterator, TextInput} from 'react-admin'
 
 // TODO: treba zistit, ako ma vyzerat tento PUT request a teda form, potom otestovat

--- a/src/pages/Admin/Post/PostEdit.tsx
+++ b/src/pages/Admin/Post/PostEdit.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {
   ArrayInput,
   DateInput,

--- a/src/pages/Admin/Post/PostList.tsx
+++ b/src/pages/Admin/Post/PostList.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {Datagrid, DateField, List, ListProps, NumberField, TextField} from 'react-admin'
 
 export const PostList: FC<ListProps> = (props) => (

--- a/src/pages/Admin/Post/PostShow.tsx
+++ b/src/pages/Admin/Post/PostShow.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import {FC} from 'react'
 import {
   ArrayField,
   Datagrid,

--- a/src/pages/PagePlaceholder/PagePlaceholder.tsx
+++ b/src/pages/PagePlaceholder/PagePlaceholder.tsx
@@ -1,7 +1,7 @@
 // import './PagePlaceholder.css'
-import React from 'react'
+import {FC} from 'react'
 
-export const PagePlaceholder: React.FC<{title: string}> = ({title}) => {
+export const PagePlaceholder: FC<{title: string}> = ({title}) => {
   return (
     <div className="placeholder">
       <h1>{title}</h1>

--- a/src/pages/Post/Post.tsx
+++ b/src/pages/Post/Post.tsx
@@ -1,6 +1,6 @@
 // import './Post.css'
 import axios, {AxiosError} from 'axios'
-import React, {FC, useEffect, useState} from 'react'
+import {FC, useEffect, useState} from 'react'
 
 interface IPost {
   id: number

--- a/src/pages/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterForm/RegisterForm.tsx
@@ -1,7 +1,7 @@
 // import './RegisterForm.css'
 import {Button} from '@material-ui/core'
 import axios from 'axios'
-import React, {FC, useEffect, useState} from 'react'
+import {FC, useEffect, useState} from 'react'
 import {SubmitHandler, useForm} from 'react-hook-form'
 
 import {FormCheckbox} from '../../components/FormItems/FormCheckbox/FormCheckbox'

--- a/src/pages/VerifyEmail/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail/VerifyEmail.tsx
@@ -1,8 +1,8 @@
 import axios, {AxiosError} from 'axios'
 import {useRouter} from 'next/router'
-import React, {useEffect, useState} from 'react'
+import {FC, useEffect, useState} from 'react'
 
-export const VerifyEmail: React.FC = () => {
+export const VerifyEmail: FC = () => {
   const router = useRouter()
   const {verificationKey} = router.query
   const [response, setResponse] = useState('')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4687,15 +4687,14 @@ react-cookie@^4.0.3:
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
 
-react-dom@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-dropzone@^10.1.7:
   version "10.2.2"
@@ -4802,14 +4801,13 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -5120,10 +5118,10 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
based on #27, potom rebasnem

React 17 podporuje novy JSX transform, co znamena, ze pre pouzitie JSX v komponentoch netreba mat `React` import. tu je nieco viac o tom: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports

spustil som spominany codemod, eslint --fix a doupravil vsetky zvysne importy, nech uz destructurujeme vsetko.