### PR TITLE
Fix Material UI import in react admin

### DIFF
--- a/src/components/Admin/custom/MyArrayField.tsx
+++ b/src/components/Admin/custom/MyArrayField.tsx
@@ -1,4 +1,4 @@
-import {Chip} from '@material-ui/core'
+import {Chip} from '@mui/material'
 import {FC} from 'react'
 import {FieldProps} from 'react-admin'
 


### PR DESCRIPTION
robilo to ESLint error, aj ked funkcne to asi slo, kedze je `@material-ui/core` subdependencia react admina