### PR TITLE
remove `contentWidth` on `/strom` for consistency

### DIFF
--- a/src/pages/strom/index.tsx
+++ b/src/pages/strom/index.tsx
@@ -4,7 +4,7 @@ import {PageLayout} from '@/components/PageLayout/PageLayout'
 import {Posts} from '@/components/Post/Post'
 
 const Strom: NextPage = () => (
-  <PageLayout contentWidth={1} title="Seminár Strom">
+  <PageLayout title="Seminár Strom">
     <Posts seminarId={1} />
   </PageLayout>
 )


### PR DESCRIPTION
fixes menu covering content:
<img width="962" alt="image" src="https://user-images.githubusercontent.com/6044119/208242491-bb284c39-e48f-4019-a521-a657563a4dc9.png">
