### PR TITLE
Remove trailing slash from requests to avoid the unnecessary 308 redirect from next.js side

### DIFF
--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -32,7 +32,7 @@ const PublicationButton: FC<{
   publicationId: number
   publicationName: string
 }> = ({publicationId, publicationName}) => {
-  return <Link href={`/api/competition/publication/${publicationId}/download/`}>{publicationName}</Link>
+  return <Link href={`/api/competition/publication/${publicationId}/download`}>{publicationName}</Link>
 }
 
 const ResultsButton: FC<{

--- a/src/components/PageLayout/MenuMain/MenuMain.tsx
+++ b/src/components/PageLayout/MenuMain/MenuMain.tsx
@@ -30,7 +30,7 @@ export const MenuMain: FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const {data} = await axios.get<MenuItemInterface[]>(`/api/cms/menu-item/on-site/${seminarId}/`)
+        const {data} = await axios.get<MenuItemInterface[]>(`/api/cms/menu-item/on-site/${seminarId}`)
         setMenuItems(data)
       } catch {
         return

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -24,7 +24,7 @@ export const Posts: FC<{seminarId: number}> = ({seminarId}) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const {data} = await axios.get<IPost[]>('/api/cms/post/visible/', {
+        const {data} = await axios.get<IPost[]>('/api/cms/post/visible', {
           headers: {
             'Content-type': 'application/json',
           },

--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -56,9 +56,9 @@ const Problem: FC<{
       <h3 className={styles.problemTitle}>{problem.order}. ÚLOHA</h3>
       <Latex>{problem.text}</Latex>
       <div className={styles.actions}>
-        {registered ? <Link href={`/api/competition/problem/${problem.id}/my-solution/`}>moje riešenie</Link> : <></>}
+        {registered ? <Link href={`/api/competition/problem/${problem.id}/my-solution`}>moje riešenie</Link> : <></>}
         {registered ? (
-          <Link href={`/api/competition/problem/${problem.id}/corrected-solution/`}>
+          <Link href={`/api/competition/problem/${problem.id}/corrected-solution`}>
             opravené riešenie ({problem.submitted?.score || '?'})
           </Link>
         ) : (

--- a/src/components/Problems/SemesterPicker.tsx
+++ b/src/components/Problems/SemesterPicker.tsx
@@ -39,7 +39,7 @@ export const SemesterPicker: FC<{semesterList: SemesterList[]; selectedSeriesId:
     return {
       id: semester.id,
       text: `${semester.year}. Ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,
-      link: `/${seminar}/zadania/${semester.year}/${semester.season_code === 0 ? 'zima' : 'leto'}/`,
+      link: `/${seminar}/zadania/${semester.year}/${semester.season_code === 0 ? 'zima' : 'leto'}`,
     }
   })
 
@@ -55,7 +55,7 @@ export const SemesterPicker: FC<{semesterList: SemesterList[]; selectedSeriesId:
             text: `${series.order}. séria`,
             link: `/${seminar}/zadania/${semesterList[i].year}/${semesterList[i].season_code === 0 ? 'zima' : 'leto'}/${
               series.order
-            }/`,
+            }`,
           }
         })
       }

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -79,7 +79,7 @@ export const RegisterForm: FC = () => {
   // načítanie ročníkov z BE, ktorými vyplníme FormSelect s ročníkmi
   useEffect(() => {
     const fetchData = async () => {
-      const grades = await axios.get<IGrade[]>(`/api/competition/grade/`)
+      const grades = await axios.get<IGrade[]>(`/api/competition/grade`)
       setGradeItems(grades.data.map(({id, name}) => ({id, label: name})))
     }
     fetchData()
@@ -99,7 +99,7 @@ export const RegisterForm: FC = () => {
   // načítanie krajov z BE, ktorými vyplníme FormSelect s krajmi
   useEffect(() => {
     const fetchData = async () => {
-      const counties = await axios.get<ICounty[]>(`/api/personal/counties/`)
+      const counties = await axios.get<ICounty[]>(`/api/personal/counties`)
       setCountyItems(counties.data.map(({code, name}) => ({id: code, label: name})))
     }
     fetchData()
@@ -189,7 +189,7 @@ export const RegisterForm: FC = () => {
 
   const onSubmit: SubmitHandler<RegisterFormValues> = async (data) => {
     try {
-      const response = await axios.post<IGeneralPostResponse>(`/api/user/registration/`, transformFormData(data))
+      const response = await axios.post<IGeneralPostResponse>(`/api/user/registration`, transformFormData(data))
       setSuccessfulRegistration(response.data.detail)
     } catch (error: unknown) {
       // TODO: error handling

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -198,7 +198,7 @@ export const Results: FC<ResultsProps> = ({setPageTitle}) => {
     const fetchData = async () => {
       try {
         const {data} = await axios.get<Result[]>(
-          '/api/competition/' + (resultsId.semester === true ? 'semester/' : 'series/') + resultsId.id + '/results/',
+          '/api/competition/' + (resultsId.semester === true ? 'semester/' : 'series/') + resultsId.id + '/results',
           {
             headers: {
               'Content-type': 'application/json',
@@ -352,7 +352,7 @@ const Menu: FC<{semesterList: SemesterList[]; selectedId: {semester: boolean; id
     return {
       id: semester.id,
       text: `${semester.year}. Ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,
-      link: `/${seminar}/vysledky/${semester.year}/${semester.season_code === 0 ? 'zima' : 'leto'}/`,
+      link: `/${seminar}/vysledky/${semester.year}/${semester.season_code === 0 ? 'zima' : 'leto'}`,
     }
   })
 
@@ -367,7 +367,7 @@ const Menu: FC<{semesterList: SemesterList[]; selectedId: {semester: boolean; id
           text: `${series.order}. séria`,
           link: `/${seminar}/vysledky/${semesterList[i].year}/${semesterList[i].season_code === 0 ? 'zima' : 'leto'}/${
             series.order
-          }/`,
+          }`,
         }
       })
     } else if (selectedId.semester === false) {
@@ -381,7 +381,7 @@ const Menu: FC<{semesterList: SemesterList[]; selectedId: {semester: boolean; id
               text: `${series.order}. séria`,
               link: `/${seminar}/vysledky/${semesterList[i].year}/${
                 semesterList[i].season_code === 0 ? 'zima' : 'leto'
-              }/${series.order}/`,
+              }/${series.order}`,
             }
           })
         }

--- a/src/components/VerifyEmail/VerifyEmail.tsx
+++ b/src/components/VerifyEmail/VerifyEmail.tsx
@@ -10,7 +10,7 @@ export const VerifyEmail: FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = await axios.post('/api/user/registration/verify-email/', {key: verificationKey})
+        const data = await axios.post('/api/user/registration/verify-email', {key: verificationKey})
         const response =
           data.status === 200 ? 'Email successfully verified' : 'An unexpected response status code has occurred'
         setResponse(response)

--- a/src/pages/strom/[page].tsx
+++ b/src/pages/strom/[page].tsx
@@ -28,7 +28,7 @@ export const seminarBasedGetServerSideProps = (seminar: Seminar): GetServerSideP
   if (query?.page && typeof query.page === 'string') {
     const requestedUrl = query.page
     const {data} = await axios.get<FlatPage | undefined>(
-      `${process.env.NEXT_PUBLIC_BE_URL}/base/flat-page/by-url/${requestedUrl}/`,
+      `${process.env.NEXT_PUBLIC_BE_URL}/base/flat-page/by-url/${requestedUrl}`,
     )
     // ked stranka neexistuje, vrati sa `content: ""`. teraz renderujeme stranku len ked je content neprazdny a server rovno vrati redirect.
     // druha moznost by bola nechat prazdny content handlovat clienta - napriklad zobrazit custom error, ale nechat usera na neplatnej stranke.

--- a/src/pages/strom/akcie/[[...params]].tsx
+++ b/src/pages/strom/akcie/[[...params]].tsx
@@ -81,7 +81,7 @@ export const competitionBasedGetServerSideProps = (
 
     try {
       const {data} = await axios.get<OurCompetition | undefined>(
-        `${process.env.NEXT_PUBLIC_BE_URL}/competition/competition/${requestedUrl}/`,
+        `${process.env.NEXT_PUBLIC_BE_URL}/competition/competition/${requestedUrl}`,
       )
       if (!data) return redirectToSeminar
 

--- a/src/utils/AuthContainer.tsx
+++ b/src/utils/AuthContainer.tsx
@@ -92,7 +92,7 @@ const useAuth = () => {
   const logout = async () => {
     // Funkcia, ktorá zavolá logout API point, ktorý zmaže token na BE a odstráni sessionid cookie.
     try {
-      await axios.post('/api/user/logout/')
+      await axios.post('/api/user/logout')
     } catch (e: unknown) {
       const ex = e as AxiosError
       const error = ex.response?.status === 404 ? 'Resource not found' : 'An unexpected error has occurred'

--- a/src/utils/ProfileContainer.tsx
+++ b/src/utils/ProfileContainer.tsx
@@ -12,7 +12,7 @@ const useProfile = () => {
 
   const fetchProfile = async () => {
     try {
-      const {data} = await profileAxios.get<Profile>(`/api/personal/profiles/myprofile/`)
+      const {data} = await profileAxios.get<Profile>(`/api/personal/profiles/myprofile`)
       setProfile(data)
       return true
     } catch (e: unknown) {


### PR DESCRIPTION
https://github.com/ZdruzenieSTROM/webstrom-frontend/blob/master/docs/trailing-slash.md vysvetluje, ako vlastne requesty chceme definovat bez koncoveho lomitka, lebo tam inak next.js dava zbytocny 308 redirect, aj ked to potom rewrite v `next.config.js` prepise do formatu s lomitkom 😄 trochu zmatok, ale co uz