### PR TITLE
Map Typography variants to span element

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -56,6 +56,44 @@ const _theme = createTheme({
     subtitle1: undefined,
     subtitle2: undefined,
   },
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          body1: 'span',
+          body2: 'span',
+          body3: 'span',
+          button1: 'span',
+          button2: 'span',
+          button3: 'span',
+          postTitle: 'span',
+          postBody: 'span',
+        },
+      },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          '& > div.MuiDialogContent-root': {paddingTop: '20px'},
+          border: '10px solid black',
+        },
+      },
+    },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          paddingBottom: '20px',
+        },
+      },
+    },
+    MuiDialogTitle: {
+      styleOverrides: {
+        root: {
+          textAlign: 'center',
+        },
+      },
+    },
+  },
 })
 
 const pxToRem = _theme.typography.pxToRem
@@ -64,6 +102,7 @@ const md = _theme.breakpoints.up('md') // 900px
 const lg = _theme.breakpoints.up('lg') // 1200px
 const xl = _theme.breakpoints.up('xl') // 1536px
 
+// manual font sizes
 export const theme: Theme = {
   ..._theme,
   typography: {
@@ -173,30 +212,6 @@ export const theme: Theme = {
       [md]: {fontSize: pxToRem(24)},
       [lg]: {fontSize: pxToRem(24)},
       [xl]: {fontSize: pxToRem(30)},
-    },
-  },
-  components: {
-    MuiDialog: {
-      styleOverrides: {
-        paper: {
-          '& > div.MuiDialogContent-root': {paddingTop: '20px'},
-          border: '10px solid black',
-        },
-      },
-    },
-    MuiDialogActions: {
-      styleOverrides: {
-        root: {
-          paddingBottom: '20px',
-        },
-      },
-    },
-    MuiDialogTitle: {
-      styleOverrides: {
-        root: {
-          textAlign: 'center',
-        },
-      },
     },
   },
 }


### PR DESCRIPTION
netestoval som ziadny inu stranku, ktoru by toto mohlo rozbit.
EDIT: ok, par som ich preklikal, vyzera to ok.

before:
<img width="677" alt="image" src="https://github.com/ZdruzenieSTROM/webstrom-frontend/assets/6044119/bb0e178e-ee19-4a09-904f-5d2f0661c1eb">

now: 
<img width="641" alt="image" src="https://github.com/ZdruzenieSTROM/webstrom-frontend/assets/6044119/fea5eb5d-683e-4bd5-ba93-d4cfd48a79ec">
