### PR TITLE
React Admin - Semester, Serie

### DIFF
--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -17,6 +17,10 @@ import {EventCreate} from './resources/competition/event/EventCreate'
 import {EventEdit} from './resources/competition/event/EventEdit'
 import {EventList} from './resources/competition/event/EventList'
 import {EventShow} from './resources/competition/event/EventShow'
+import {SemesterCreate} from './resources/competition/semester/SemesterCreate'
+import {SemesterEdit} from './resources/competition/semester/SemesterEdit'
+import {SemesterList} from './resources/competition/semester/SemesterList'
+import {SemesterShow} from './resources/competition/semester/SemesterShow'
 import {SeriesEdit} from './resources/competition/series/SeriesEdit'
 import {SeriesList} from './resources/competition/series/SeriesList'
 import {SeriesShow} from './resources/competition/series/SeriesShow'
@@ -35,9 +39,23 @@ export const Admin: FC = () => {
         show={FlatpageShow}
         create={FlatpageCreate}
       />
-      {/* nedovolujeme create na competition - velmi rare vec, ani nemame BE POST endpoint na to */}
-      <Resource name="competition/competition" list={CompetitionList} edit={CompetitionEdit} show={CompetitionShow} />
+      <Resource
+        name="competition/competition"
+        // helps with option names in ReferenceInput
+        recordRepresentation="name"
+        list={CompetitionList}
+        edit={CompetitionEdit}
+        show={CompetitionShow}
+        // nedovolujeme create na competition - velmi rare flow, ani nemame BE POST endpoint na to
+      />
       <Resource name="competition/event" list={EventList} edit={EventEdit} show={EventShow} create={EventCreate} />
+      <Resource
+        name="competition/semester"
+        list={SemesterList}
+        edit={SemesterEdit}
+        show={SemesterShow}
+        create={SemesterCreate}
+      />
       <Resource name="competition/series" list={SeriesList} edit={SeriesEdit} show={SeriesShow} />
     </ReactAdmin>
   )

--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -28,10 +28,6 @@ export const Admin: FC = () => {
   return (
     <ReactAdmin authProvider={authProvider} dataProvider={dataProvider}>
       <Resource name="cms/post" list={PostList} edit={PostEdit} show={PostShow} create={PostCreate} />
-      <Resource name="competition/series" list={SeriesList} edit={SeriesEdit} show={SeriesShow} />
-      <Resource name="competition/event" list={EventList} edit={EventEdit} show={EventShow} create={EventCreate} />
-      {/* nedovolujeme create na competition - velmi rare vec, ani nemame BE POST endpoint na to */}
-      <Resource name="competition/competition" list={CompetitionList} edit={CompetitionEdit} show={CompetitionShow} />
       <Resource
         name="base/flat-page"
         list={FlatpageList}
@@ -39,6 +35,10 @@ export const Admin: FC = () => {
         show={FlatpageShow}
         create={FlatpageCreate}
       />
+      {/* nedovolujeme create na competition - velmi rare vec, ani nemame BE POST endpoint na to */}
+      <Resource name="competition/competition" list={CompetitionList} edit={CompetitionEdit} show={CompetitionShow} />
+      <Resource name="competition/event" list={EventList} edit={EventEdit} show={EventShow} create={EventCreate} />
+      <Resource name="competition/series" list={SeriesList} edit={SeriesEdit} show={SeriesShow} />
     </ReactAdmin>
   )
 }

--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -21,6 +21,7 @@ import {SemesterCreate} from './resources/competition/semester/SemesterCreate'
 import {SemesterEdit} from './resources/competition/semester/SemesterEdit'
 import {SemesterList} from './resources/competition/semester/SemesterList'
 import {SemesterShow} from './resources/competition/semester/SemesterShow'
+import {SeriesCreate} from './resources/competition/series/SeriesCreate'
 import {SeriesEdit} from './resources/competition/series/SeriesEdit'
 import {SeriesList} from './resources/competition/series/SeriesList'
 import {SeriesShow} from './resources/competition/series/SeriesShow'
@@ -51,12 +52,16 @@ export const Admin: FC = () => {
       <Resource name="competition/event" list={EventList} edit={EventEdit} show={EventShow} create={EventCreate} />
       <Resource
         name="competition/semester"
+        // helps with option names in ReferenceInput
+        recordRepresentation={(semester) =>
+          `competition:${semester.competition},year:${semester.year},season:${semester.season_code}`
+        }
         list={SemesterList}
         edit={SemesterEdit}
         show={SemesterShow}
         create={SemesterCreate}
       />
-      <Resource name="competition/series" list={SeriesList} edit={SeriesEdit} show={SeriesShow} />
+      <Resource name="competition/series" list={SeriesList} edit={SeriesEdit} show={SeriesShow} create={SeriesCreate} />
     </ReactAdmin>
   )
 }

--- a/src/components/Admin/dataProvider.ts
+++ b/src/components/Admin/dataProvider.ts
@@ -39,7 +39,8 @@ export const dataProvider: DataProvider = {
       // ...getPaginationQuery(params.pagination),
       // ...getOrderingQuery(params.sort),
     }
-    const {data} = await axios.get(`${apiUrl}/${resource}/?${stringify(query)}`)
+    const stringifiedQuery = stringify(query)
+    const {data} = await axios.get(`${apiUrl}/${resource}${stringifiedQuery ? `/?${stringifiedQuery}` : ''}`)
 
     // client-side sort
     const {field, order} = params.sort

--- a/src/components/Admin/resources/competition/competition/CompetitionEdit.tsx
+++ b/src/components/Admin/resources/competition/competition/CompetitionEdit.tsx
@@ -14,7 +14,7 @@ export const CompetitionEdit: FC = () => (
       <TextInput source="rules" multiline fullWidth />
       <TextInput source="competition_type.name" label="Competition type" fullWidth disabled />
       <SitesCheckboxInput source="sites" disabled />
-      <TextInput source="who_can_participate" multiline fullWidth />
+      <TextInput source="who_can_participate" fullWidth />
       <NumberInput source="min_years_until_graduation" fullWidth disabled />
     </SimpleForm>
   </MyEdit>

--- a/src/components/Admin/resources/competition/competition/UpcomingOrCurrentEvent.tsx
+++ b/src/components/Admin/resources/competition/competition/UpcomingOrCurrentEvent.tsx
@@ -37,7 +37,8 @@ export const UpcomingOrCurrentEvent: FC = () => {
         <FunctionField<RaRecord>
           source="publication_set"
           label="Publication count"
-          render={(record) => record && <span>{record['publication_set'].length}</span>}
+          // optional access because of weird behavior of nested FunctionFields for null record
+          render={(record) => record && <span>{record['publication_set']?.length}</span>}
         />
       </SimpleShowLayout>
     </Labeled>

--- a/src/components/Admin/resources/competition/semester/SemesterCreate.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterCreate.tsx
@@ -1,0 +1,37 @@
+import {FC} from 'react'
+import {
+  CheckboxGroupInput,
+  DateTimeInput,
+  NumberInput,
+  ReferenceArrayInput,
+  ReferenceInput,
+  required,
+  SelectInput,
+  SimpleForm,
+  TextInput,
+} from 'react-admin'
+
+import {MyCreate} from '@/components/Admin/custom/MyCreate'
+
+export const SemesterCreate: FC = () => (
+  <MyCreate>
+    <SimpleForm>
+      <ReferenceInput source="competition" reference="competition/competition">
+        <SelectInput fullWidth validate={required()} />
+      </ReferenceInput>
+      <NumberInput source="year" fullWidth validate={required()} />
+      <NumberInput source="season_code" fullWidth validate={required()} />
+      <TextInput source="school_year" fullWidth />
+      <DateTimeInput source="start" fullWidth validate={required()} />
+      <DateTimeInput source="end" fullWidth validate={required()} />
+      <TextInput source="additional_name" fullWidth />
+      {/* nechavam viditelne disabled nech sa rozhodneme, co s tym. BE nam posiela ID, 
+          neviem, ci vieme updatnut cely objekt tym, ze ho pribalim, ako v EventEdit...
+          uvidime, ci ten field vobec potrebujeme */}
+      <NumberInput source="registration_link" fullWidth disabled />
+      <ReferenceArrayInput source="late_tags" reference="competition/late-tag">
+        <CheckboxGroupInput />
+      </ReferenceArrayInput>
+    </SimpleForm>
+  </MyCreate>
+)

--- a/src/components/Admin/resources/competition/semester/SemesterEdit.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterEdit.tsx
@@ -1,0 +1,48 @@
+import {FC} from 'react'
+import {
+  CheckboxGroupInput,
+  DateTimeInput,
+  FormTab,
+  NumberInput,
+  ReferenceArrayInput,
+  ReferenceInput,
+  required,
+  SelectInput,
+  TabbedForm,
+  TextInput,
+} from 'react-admin'
+
+import {MyEdit} from '@/components/Admin/custom/MyEdit'
+
+export const SemesterEdit: FC = () => (
+  <MyEdit
+    transform={(record) => {
+      // automaticky sa na BE posiela cely record, ale BE read_only (aj neexistujuce) fieldy ignoruje
+      // radsej z payloadu odstranime aspon sety
+      delete record.publication_set
+      delete record.series_set
+      return record
+    }}
+  >
+    <TabbedForm>
+      <FormTab label="general">
+        <ReferenceInput source="competition" reference="competition/competition">
+          <SelectInput fullWidth validate={required()} />
+        </ReferenceInput>
+        <NumberInput source="year" fullWidth />
+        <NumberInput source="season_code" fullWidth />
+        <TextInput source="school_year" fullWidth />
+        <DateTimeInput source="start" fullWidth />
+        <DateTimeInput source="end" fullWidth />
+        <TextInput source="additional_name" fullWidth />
+        {/* nechavam viditelne disabled nech sa rozhodneme, co s tym. BE nam posiela ID, 
+            neviem, ci vieme updatnut cely objekt tym, ze ho pribalim, ako v EventEdit...
+            uvidime, ci ten field vobec potrebujeme */}
+        <NumberInput source="registration_link" fullWidth disabled />
+        <ReferenceArrayInput source="late_tags" reference="competition/late-tag">
+          <CheckboxGroupInput />
+        </ReferenceArrayInput>
+      </FormTab>
+    </TabbedForm>
+  </MyEdit>
+)

--- a/src/components/Admin/resources/competition/semester/SemesterList.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterList.tsx
@@ -1,0 +1,35 @@
+import {FC} from 'react'
+import {BooleanField, Datagrid, DateField, FunctionField, List, NumberField, RaRecord, TextField} from 'react-admin'
+
+import {CompetitionField} from '@/components/Admin/custom/CompetitionField'
+
+export const SemesterList: FC = () => (
+  <List>
+    <Datagrid rowClick="show">
+      <CompetitionField source="competition" />
+      <NumberField source="year" />
+      <NumberField source="season_code" />
+      <TextField source="school_year" />
+      <DateField source="start" />
+      <DateField source="end" />
+      <BooleanField source="complete" />
+      <TextField source="additional_name" />
+      <NumberField source="registration_link" />
+      <FunctionField<RaRecord>
+        source="series_set"
+        label="Series count"
+        render={(record) => record && <span>{record['series_set'].length}</span>}
+      />
+      <FunctionField<RaRecord>
+        source="publication_set"
+        label="Publication count"
+        render={(record) => record && <span>{record['publication_set'].length}</span>}
+      />
+      <FunctionField<RaRecord>
+        source="late_tags"
+        label="Late tags count"
+        render={(record) => record && <span>{record['late_tags'].length}</span>}
+      />
+    </Datagrid>
+  </List>
+)

--- a/src/components/Admin/resources/competition/semester/SemesterShow.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterShow.tsx
@@ -1,0 +1,78 @@
+import {FC} from 'react'
+import {
+  ArrayField,
+  BooleanField,
+  Datagrid,
+  DateField,
+  NumberField,
+  ReferenceArrayField,
+  ReferenceField,
+  Show,
+  SimpleShowLayout,
+  Tab,
+  TabbedShowLayout,
+  TextField,
+} from 'react-admin'
+
+import {MyShowActions} from '@/components/Admin/custom/MyShowActions'
+import {TruncatedTextField} from '@/components/Admin/custom/TruncatedTextField'
+
+export const SemesterShow: FC = () => (
+  <Show actions={<MyShowActions />}>
+    <TabbedShowLayout>
+      <Tab label="general">
+        <SimpleShowLayout>
+          <ReferenceField source="competition" reference="competition/competition" link="show" />
+          <NumberField source="year" />
+          <NumberField source="season_code" />
+          <TextField source="school_year" />
+          <DateField source="start" />
+          <DateField source="end" />
+          <BooleanField source="complete" />
+          <TextField source="additional_name" />
+          <NumberField source="registration_link" />
+        </SimpleShowLayout>
+      </Tab>
+      <Tab label="series">
+        <SimpleShowLayout>
+          <ArrayField source="series_set">
+            <Datagrid rowClick={(id) => `/competition/series/${id}/show`}>
+              <DateField source="deadline" />
+              <TextField source="order" />
+              <ArrayField source="problems">
+                <Datagrid>
+                  <TruncatedTextField source="text" maxTextWidth={50} />
+                </Datagrid>
+              </ArrayField>
+            </Datagrid>
+          </ArrayField>
+        </SimpleShowLayout>
+      </Tab>
+      <Tab label="publications">
+        <SimpleShowLayout>
+          <ArrayField source="publication_set">
+            <Datagrid>
+              <TextField source="name" />
+              <TextField source="file" />
+              <NumberField source="publication_type" />
+              <NumberField source="event" />
+              <NumberField source="order" />
+            </Datagrid>
+          </ArrayField>
+        </SimpleShowLayout>
+      </Tab>
+      <Tab label="late tags">
+        <SimpleShowLayout>
+          <ReferenceArrayField source="late_tags" reference="competition/late-tag">
+            <Datagrid>
+              <TextField source="name" />
+              <TextField source="slug" />
+              <TextField source="upper_bound" />
+              <BooleanField source="can_resubmit" />
+            </Datagrid>
+          </ReferenceArrayField>
+        </SimpleShowLayout>
+      </Tab>
+    </TabbedShowLayout>
+  </Show>
+)

--- a/src/components/Admin/resources/competition/series/SeriesCreate.tsx
+++ b/src/components/Admin/resources/competition/series/SeriesCreate.tsx
@@ -10,17 +10,10 @@ import {
   TextInput,
 } from 'react-admin'
 
-import {MyEdit} from '@/components/Admin/custom/MyEdit'
+import {MyCreate} from '@/components/Admin/custom/MyCreate'
 
-export const SeriesEdit: FC = () => (
-  <MyEdit
-    transform={(record) => {
-      // automaticky sa na BE posiela cely record, ale BE read_only (aj neexistujuce) fieldy ignoruje
-      // radsej z payloadu odstranime aspon sety
-      delete record.problems
-      return record
-    }}
-  >
+export const SeriesCreate: FC = () => (
+  <MyCreate>
     <TabbedForm>
       <FormTab label="general">
         <ReferenceInput source="semester" reference="competition/semester">
@@ -31,5 +24,5 @@ export const SeriesEdit: FC = () => (
         <BooleanInput source="complete" disabled />
       </FormTab>
     </TabbedForm>
-  </MyEdit>
+  </MyCreate>
 )

--- a/src/components/Admin/resources/competition/series/SeriesList.tsx
+++ b/src/components/Admin/resources/competition/series/SeriesList.tsx
@@ -1,20 +1,17 @@
 import {FC} from 'react'
-import {ArrayField, Datagrid, DateField, List, TextField} from 'react-admin'
+import {BooleanField, Datagrid, DateField, FunctionField, List, RaRecord, ReferenceField, TextField} from 'react-admin'
 
-import {TruncatedTextField} from '@/components/Admin/custom/TruncatedTextField'
-
-// TODO: premysliet a prerobit rozhranie, mozno ako u postov - pri kliku na riadok ukazat Show, kde budu priklady
-// (nie ako teraz v zanorenom Datagride)
 export const SeriesList: FC = () => (
   <List>
     <Datagrid rowClick="show">
+      <ReferenceField source="semester" reference="competition/semester" link={false} />
       <DateField source="deadline" />
       <TextField source="order" />
-      <ArrayField source="problems">
-        <Datagrid>
-          <TruncatedTextField source="text" maxTextWidth={50} />
-        </Datagrid>
-      </ArrayField>
+      <BooleanField source="complete" />
+      <FunctionField<RaRecord>
+        label="Problem count"
+        render={(record) => record && <span>{record['problems'].length}</span>}
+      />
     </Datagrid>
   </List>
 )

--- a/src/components/Admin/resources/competition/series/SeriesShow.tsx
+++ b/src/components/Admin/resources/competition/series/SeriesShow.tsx
@@ -4,7 +4,7 @@ import {
   BooleanField,
   Datagrid,
   DateField,
-  NumberField,
+  ReferenceField,
   Show,
   SimpleShowLayout,
   Tab,
@@ -20,10 +20,9 @@ export const SeriesShow: FC = () => (
     <TabbedShowLayout>
       <Tab label="general">
         <SimpleShowLayout>
+          <ReferenceField source="semester" reference="competition/semester" link="show" />
           <DateField source="deadline" />
           <TextField source="order" />
-          <NumberField source="semester" />
-          <BooleanField source="frozen_results" />
           <BooleanField source="complete" />
         </SimpleShowLayout>
       </Tab>


### PR DESCRIPTION
mal by teraz fungovat reasonable Create/Edit na Semestroch aj na Seriach.
related sety sa excluduju z edit requestov (aj ked ich uz BE nechrume, ignoruje ich) a treba ich vsetky handlovat a nalinkovat osobitne.
len maly prehlad:
- Competition ma Eventy -> pri edite Eventu sa voli Competion, ku ktorej patri ✅ 
- Event maju Publikacie -> treba zrobic edit Publikacii ❌ 
- pri edite Semestru sa voli Competion, ku ktorej patri ✅ 
- Semester ma Serie -> pri edite Serie sa voli semester, ku ktoremu patri ✅ 
- Semester ma Publikacie -> treba zrobic edit Publikacii ❌ 
- Semester ma Late tagy -> actually tieto sa vyberaju priamo pri edite Semestra a budu vzdy prepisovat aktualny array ✅ 
- Seria ma Problemy -> treba zrobic edit Problemov ❌ 

zatvorime tieto (closes #290 #188) a pre #188 spravime followup na problemy