### PR TITLE
React Admin: remove `id` from PATCH (edit) body

### DIFF
--- a/src/components/Admin/dataProvider.ts
+++ b/src/components/Admin/dataProvider.ts
@@ -79,7 +79,8 @@ export const dataProvider: DataProvider = {
     }
   },
   update: async (resource, params) => {
-    const {data} = await axios.patch(`${apiUrl}/${resource}/${params.id}`, params.data)
+    const {id, ...input} = params.data
+    const {data} = await axios.patch(`${apiUrl}/${resource}/${id}`, input)
 
     return {data}
   },


### PR DESCRIPTION
fixuje spravanie napr. pri edite Post linkov - posielame tam cely array (viac info tu: https://github.com/ZdruzenieSTROM/webstrom-backend/issues/327), presnejsie uplne cely Post objekt. BE nested serializer sa z nejakeho dovodu sprava inak, ak je `id` v body toho requestu, a byt tam nemusi (nema), kedze je sucastou URL