### PR TITLE
Matush/Semester picker in administration

### DIFF
--- a/src/components/PageLayout/MenuMain/MenuMain.tsx
+++ b/src/components/PageLayout/MenuMain/MenuMain.tsx
@@ -10,7 +10,6 @@ import {CloseButton} from '@/components/CloseButton/CloseButton'
 import {Loading} from '@/components/Loading/Loading'
 import Menu from '@/svg/menu.svg'
 import {MenuItemShort} from '@/types/api/cms'
-import {useDataFromURL} from '@/utils/useDataFromURL'
 import {useHasPermissions} from '@/utils/useHasPermissions'
 import {useSeminarInfo} from '@/utils/useSeminarInfo'
 
@@ -19,7 +18,6 @@ import styles from './MenuMain.module.scss'
 
 export const MenuMain: FC = () => {
   const {seminar, seminarId} = useSeminarInfo()
-  const {id} = useDataFromURL()
 
   const {hasPermissions} = useHasPermissions()
 

--- a/src/components/PageLayout/MenuMain/MenuMain.tsx
+++ b/src/components/PageLayout/MenuMain/MenuMain.tsx
@@ -74,7 +74,7 @@ export const MenuMain: FC = () => {
           </Stack>
           {hasPermissions && (
             <Stack sx={{mt: 4, mx: 2, borderTop: '8px dashed white', pt: 4}}>
-              <MenuMainItem caption="TODO: Opravovanie" url={`/${seminar}/admin/opravovanie/${id.semesterId}`} />
+              <MenuMainItem caption="Opravovanie" url={`/${seminar}/admin/opravovanie/`} />
               <MenuMainItem caption="Admin" url="/admin" />
             </Stack>
           )}

--- a/src/components/PageLayout/TopGrid/TopGrid.tsx
+++ b/src/components/PageLayout/TopGrid/TopGrid.tsx
@@ -2,7 +2,7 @@ import {Stack, Typography} from '@mui/material'
 import clsx from 'clsx'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
-import {FC} from 'react'
+import {FC, useMemo} from 'react'
 
 import {SemesterPicker} from '@/components/SemesterPicker/SemesterPicker'
 import {PageTitleContainer} from '@/utils/PageTitleContainer'
@@ -15,7 +15,17 @@ export const TopGrid: FC = () => {
   const {seminar} = useSeminarInfo()
 
   // z napr. `/matik/zadania(/*)` vytiahne `zadania`
-  const page = useRouter().pathname.split('/')[2]
+  const pathname = useRouter().pathname.split('/')
+
+  const semesterPickerPage = useMemo(() => {
+    if (pathname[2] === 'zadania' || pathname[2] === 'vysledky') {
+      return pathname[2]
+    }
+    if (pathname[2] === 'admin' && pathname[3] === 'opravovanie') {
+      return 'admin/opravovanie'
+    }
+    return undefined
+  }, [pathname])
 
   const {pageTitle} = PageTitleContainer.useContainer()
 
@@ -42,9 +52,9 @@ export const TopGrid: FC = () => {
         <Typography variant="h1" className={styles.title}>
           {pageTitle}
         </Typography>
-        {(page === 'zadania' || page === 'vysledky') && (
+        {semesterPickerPage && (
           <div className={styles.semesterPicker}>
-            <SemesterPicker page={page} />
+            <SemesterPicker page={semesterPickerPage} />
           </div>
         )}
       </div>

--- a/src/components/ProblemAdministration/ProblemAdministration.module.scss
+++ b/src/components/ProblemAdministration/ProblemAdministration.module.scss
@@ -1,16 +1,3 @@
-
-
-.container {
-  display: flex;
-  flex-direction: column;
-  row-gap: 12px;
-}
-
-.rightButton{
-  display: flex;
-  justify-content: flex-end;
-}
-
 .icon {
   color: black;
 }

--- a/src/components/ProblemAdministration/ProblemAdministration.module.scss.d.ts
+++ b/src/components/ProblemAdministration/ProblemAdministration.module.scss.d.ts
@@ -1,10 +1,8 @@
 export type Styles = {
   centerCell: string
-  container: string
   icon: string
   iconDisabled: string
   input: string
-  rightButton: string
   row: string
   table: string
   tableBody: string

--- a/src/components/PublicationUploader/PublicationUploader.tsx
+++ b/src/components/PublicationUploader/PublicationUploader.tsx
@@ -8,7 +8,7 @@ import {Link} from '../Clickable/Link'
 import {FileUploader} from '../FileUploader/FileUploader'
 
 interface PublicationUploaderProps {
-  semesterId: string
+  semesterId: number
   order: number
   semesterData: SemesterWithProblems
 }
@@ -20,7 +20,7 @@ export const PublicationUploader: FC<PublicationUploaderProps> = ({semesterId, o
 
   const appendFormData = (formData: FormData) => {
     formData.append('publication_type', 'Časopisy')
-    formData.append('event', semesterId)
+    formData.append('event', semesterId.toString())
     formData.append('order', order.toString())
   }
 

--- a/src/components/SemesterAdministration/SemesterAdministration.module.scss
+++ b/src/components/SemesterAdministration/SemesterAdministration.module.scss
@@ -1,3 +1,8 @@
 .textarea {
   width: 100%;
 }
+
+.semesterPicker {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/components/SemesterAdministration/SemesterAdministration.module.scss
+++ b/src/components/SemesterAdministration/SemesterAdministration.module.scss
@@ -1,8 +1,3 @@
 .textarea {
   width: 100%;
 }
-
-.semesterPicker {
-  display: flex;
-  justify-content: flex-end;
-}

--- a/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
+++ b/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
@@ -1,5 +1,6 @@
 export type Styles = {
   textarea: string
+  semesterPicker: SemesterPicker
 }
 
 export type ClassNames = keyof Styles

--- a/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
+++ b/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
@@ -1,5 +1,4 @@
 export type Styles = {
-  semesterPicker: string
   textarea: string
 }
 

--- a/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
+++ b/src/components/SemesterAdministration/SemesterAdministration.module.scss.d.ts
@@ -1,6 +1,6 @@
 export type Styles = {
+  semesterPicker: string
   textarea: string
-  semesterPicker: SemesterPicker
 }
 
 export type ClassNames = keyof Styles

--- a/src/components/SemesterAdministration/SemesterAdministration.tsx
+++ b/src/components/SemesterAdministration/SemesterAdministration.tsx
@@ -96,9 +96,6 @@ export const SemesterAdministration: FC = () => {
 
   return (
     <>
-      <div className={styles.semesterPicker}>
-        <SemesterPicker page="admin/opravovanie" />
-      </div>
       <Typography variant="h1">
         {semester.year}. ročník ({semester.school_year}) - {semester.season_code === 0 ? 'zima' : 'leto'}
       </Typography>

--- a/src/components/SemesterAdministration/SemesterAdministration.tsx
+++ b/src/components/SemesterAdministration/SemesterAdministration.tsx
@@ -1,14 +1,13 @@
 import {Stack, Typography} from '@mui/material'
 import {useQuery} from '@tanstack/react-query'
 import axios from 'axios'
-import {useRouter} from 'next/router'
 import {FC, useState} from 'react'
 
 import {Button} from '@/components/Clickable/Button'
 import {Link} from '@/components/Clickable/Link'
-import {SemesterPicker} from '@/components/SemesterPicker/SemesterPicker'
 import {SemesterWithProblems} from '@/types/api/generated/competition'
 import {formatDateTime} from '@/utils/formatDate'
+import {useDataFromURL} from '@/utils/useDataFromURL'
 import {useHasPermissions} from '@/utils/useHasPermissions'
 
 import {Loading} from '../Loading/Loading'
@@ -27,10 +26,10 @@ interface PostalCard {
 }
 
 export const SemesterAdministration: FC = () => {
-  const router = useRouter()
-  const {params} = router.query
-
-  const semesterId = params && params[0]
+  const {
+    id: {semesterId},
+    loading: urlDataLoading,
+  } = useDataFromURL()
 
   const {hasPermissions, permissionsIsLoading} = useHasPermissions()
 
@@ -85,8 +84,14 @@ export const SemesterAdministration: FC = () => {
     )
   }
 
-  if (permissionsIsLoading || semesterIsLoading) return <Loading />
-  if (!hasPermissions) return <span>Nemáš oprávnenie na zobrazenie tejto stránky.</span>
+  if (
+    urlDataLoading.currentSeriesIsLoading ||
+    urlDataLoading.semesterListIsLoading ||
+    permissionsIsLoading ||
+    semesterIsLoading
+  )
+    return <Loading />
+  if (!hasPermissions) return <Typography variant="body1">Nemáš oprávnenie na zobrazenie tejto stránky.</Typography>
   if (semesterId === undefined || !semester)
     return (
       <Typography variant="body1">
@@ -96,10 +101,7 @@ export const SemesterAdministration: FC = () => {
 
   return (
     <>
-      <Typography variant="h1">
-        {semester.year}. ročník ({semester.school_year}) - {semester.season_code === 0 ? 'zima' : 'leto'}
-      </Typography>
-      <Typography variant="body1">Administrácia semestra pre opravovateľov.</Typography>
+      <Typography variant="h3">Administrácia semestra pre opravovateľov.</Typography>
       {semester.series_set.map((series) => (
         <Stack key={series.id} gap={1} mt={5}>
           <Typography variant="h2">{series.order}. séria</Typography>

--- a/src/components/SemesterAdministration/SemesterAdministration.tsx
+++ b/src/components/SemesterAdministration/SemesterAdministration.tsx
@@ -6,6 +6,7 @@ import {FC, useState} from 'react'
 
 import {Button} from '@/components/Clickable/Button'
 import {Link} from '@/components/Clickable/Link'
+import {SemesterPicker} from '@/components/SemesterPicker/SemesterPicker'
 import {SemesterWithProblems} from '@/types/api/generated/competition'
 import {formatDateTime} from '@/utils/formatDate'
 import {useHasPermissions} from '@/utils/useHasPermissions'
@@ -95,6 +96,9 @@ export const SemesterAdministration: FC = () => {
 
   return (
     <>
+      <div className={styles.semesterPicker}>
+        <SemesterPicker page="admin/opravovanie" />
+      </div>
       <Typography variant="h1">
         {semester.year}. ročník ({semester.school_year}) - {semester.season_code === 0 ? 'zima' : 'leto'}
       </Typography>

--- a/src/components/SemesterPicker/SemesterPicker.tsx
+++ b/src/components/SemesterPicker/SemesterPicker.tsx
@@ -28,7 +28,7 @@ export interface SemesterListItem {
   series_set: SeriesListItem[]
 }
 
-export const SemesterPicker: FC<{page: 'zadania' | 'vysledky'}> = ({page}) => {
+export const SemesterPicker: FC<{page: 'zadania' | 'vysledky' | 'admin/opravovanie'}> = ({page}) => {
   const {seminar} = useSeminarInfo()
   const {setPageTitle} = PageTitleContainer.useContainer()
 
@@ -42,7 +42,9 @@ export const SemesterPicker: FC<{page: 'zadania' | 'vysledky'}> = ({page}) => {
     let pageTitleToSet = ''
     if (semester) {
       const semesterTitle = `${semester?.year}. ročník - ${semester?.season_code === 0 ? 'zimný' : 'letný'} semester`
-      if (displayWholeSemesterOnResults) {
+      if (page === 'admin/opravovanie') {
+        pageTitleToSet = 'Opravovanie'
+      } else if (displayWholeSemesterOnResults) {
         pageTitleToSet = semesterTitle
       } else if (series) {
         pageTitleToSet = `${semesterTitle}${series?.order ? ` - ${series?.order}. séria` : ''}`
@@ -50,9 +52,17 @@ export const SemesterPicker: FC<{page: 'zadania' | 'vysledky'}> = ({page}) => {
     }
     setPageTitle(pageTitleToSet)
     // `semester` a `series` su nami vytiahnute objekty, tak mozu triggerovat effekt kazdy render. nemalo by vadit
-  }, [displayWholeSemesterOnResults, semester, series, setPageTitle])
+  }, [displayWholeSemesterOnResults, semester, series, page, setPageTitle])
 
   const dropdownSemesterList = semesterList.map((semester) => {
+    if (page === 'admin/opravovanie') {
+      return {
+        id: semester.id,
+        text: `${semester.year}. ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,
+        link: `/${seminar}/${page}/${semester.id}`,
+        selected: semester.id === selectedItem.semesterId,
+      }
+    }
     return {
       id: semester.id,
       text: `${semester.year}. ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,
@@ -85,7 +95,7 @@ export const SemesterPicker: FC<{page: 'zadania' | 'vysledky'}> = ({page}) => {
 
   return (
     <div className={styles.menu}>
-      <Dropdown title={'Séria'} options={dropdownSeriesList} />
+      {page !== 'admin/opravovanie' && <Dropdown title={'Séria'} options={dropdownSeriesList} />}
       <Dropdown title={'Semester'} options={dropdownSemesterList} />
     </div>
   )

--- a/src/components/SemesterPicker/SemesterPicker.tsx
+++ b/src/components/SemesterPicker/SemesterPicker.tsx
@@ -43,7 +43,9 @@ export const SemesterPicker: FC<{page: 'zadania' | 'vysledky' | 'admin/opravovan
     if (semester) {
       const semesterTitle = `${semester?.year}. ročník - ${semester?.season_code === 0 ? 'zimný' : 'letný'} semester`
       if (page === 'admin/opravovanie') {
-        pageTitleToSet = 'Opravovanie'
+        pageTitleToSet = `Opravovanie - ${semester?.year}/${semester?.season_code === 0 ? 'zima' : 'leto'} (${
+          semester?.school_year
+        })`
       } else if (displayWholeSemesterOnResults) {
         pageTitleToSet = semesterTitle
       } else if (series) {
@@ -55,14 +57,6 @@ export const SemesterPicker: FC<{page: 'zadania' | 'vysledky' | 'admin/opravovan
   }, [displayWholeSemesterOnResults, semester, series, page, setPageTitle])
 
   const dropdownSemesterList = semesterList.map((semester) => {
-    if (page === 'admin/opravovanie') {
-      return {
-        id: semester.id,
-        text: `${semester.year}. ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,
-        link: `/${seminar}/${page}/${semester.id}`,
-        selected: semester.id === selectedItem.semesterId,
-      }
-    }
     return {
       id: semester.id,
       text: `${semester.year}. ročník - ${semester.season_code === 0 ? 'zimný' : 'letný'} semester`,

--- a/src/pages/strom/admin/opravit-ulohu/[[...params]].tsx
+++ b/src/pages/strom/admin/opravit-ulohu/[[...params]].tsx
@@ -4,7 +4,7 @@ import {PageLayout} from '@/components/PageLayout/PageLayout'
 import {ProblemAdministration as ProblemAdministrationComponent} from '@/components/ProblemAdministration/ProblemAdministration'
 
 const ProblemAdministration: NextPage = () => (
-  <PageLayout contentWidth={2} title="Opravovanie série">
+  <PageLayout contentWidth={2} title="Opravovanie úlohy">
     <ProblemAdministrationComponent />
   </PageLayout>
 )

--- a/src/pages/strom/admin/opravovanie/[[...params]].tsx
+++ b/src/pages/strom/admin/opravovanie/[[...params]].tsx
@@ -4,7 +4,7 @@ import {PageLayout} from '@/components/PageLayout/PageLayout'
 import {SemesterAdministration as SemesterAdministrationComponent} from '@/components/SemesterAdministration/SemesterAdministration'
 
 const SemesterAdmnistration: NextPage = () => (
-  <PageLayout contentWidth={2} title="Opravovanie série">
+  <PageLayout contentWidth={2} title="Opravovanie semestra">
     <SemesterAdministrationComponent />
   </PageLayout>
 )


### PR DESCRIPTION
build on https://github.com/ZdruzenieSTROM/webstrom-frontend/pull/316, close https://github.com/ZdruzenieSTROM/webstrom-frontend/issues/303 , ale mozno by sme chceli zalozit nove issue na vytvorenie novej page, ktora by osahovala nejake rascestnik do buducnosti

~~Trochu som sa s tym hral, avsak nie som si isty ze ci to posunut do topgridu je dobry napad.~~ @vikibrezinova pozri sa na to prosim a povedz ci to takto moze byt

Prerobil som url pre seminar administraciu aby zobrazovala `/{rocnik}/{semester}` takze semester picker vie detekovat z URL co je zvoleny semseter.

Nasledne bolo este potrebne:
- [x] opravit button `Spat na semester` v administracii ulohy
- [x] bolo by vhodne do Title (alebo niekde) v administracii ulohy zaznacit na akom semestri nachadzeme