### PR TITLE
259:  Flatpage create/edit preview

### DIFF
--- a/src/components/Admin/custom/FlatpagePreview.tsx
+++ b/src/components/Admin/custom/FlatpagePreview.tsx
@@ -1,0 +1,14 @@
+import {ThemeProvider} from '@mui/material/styles'
+import {FC} from 'react'
+import {FormDataConsumer} from 'react-admin'
+
+import {Markdown} from '@/components/StaticSites/Markdown'
+import {theme} from '@/theme'
+
+export const FlatpagePreview: FC = () => {
+  return (
+    <ThemeProvider theme={theme}>
+      <FormDataConsumer>{({formData}) => <Markdown content={formData.content} />}</FormDataConsumer>
+    </ThemeProvider>
+  )
+}

--- a/src/components/Admin/custom/PostPreview.tsx
+++ b/src/components/Admin/custom/PostPreview.tsx
@@ -1,7 +1,8 @@
 import {Stack} from '@mui/material'
+import {ThemeProvider} from '@mui/material/styles'
 import Grid from '@mui/material/Unstable_Grid2'
 import {FC, useState} from 'react'
-import {FormDataConsumer, ThemeProvider} from 'react-admin'
+import {FormDataConsumer} from 'react-admin'
 
 import {Post} from '@/components/Posts/Post'
 import {PostDetail} from '@/components/Posts/PostDetail'
@@ -13,8 +14,8 @@ export const PostPreview: FC = () => {
     <ThemeProvider theme={theme}>
       <FormDataConsumer>
         {({formData}) => (
-          <Grid container>
-            <Grid xs={6}>
+          <Grid container columnSpacing={5} sx={{width: '100%'}}>
+            <Grid xs={4}>
               <Stack gap={5}>
                 <Post
                   id={0}
@@ -30,7 +31,7 @@ export const PostPreview: FC = () => {
                 />
               </Stack>
             </Grid>
-            <Grid xs={6}>
+            <Grid xs={5}>
               {isDetailOpen && <PostDetail caption={formData?.caption ?? ''} details={formData?.details ?? ''} />}
             </Grid>
           </Grid>

--- a/src/components/Admin/resources/base/flat-page/FlatpageCreate.tsx
+++ b/src/components/Admin/resources/base/flat-page/FlatpageCreate.tsx
@@ -1,17 +1,23 @@
 import {FC} from 'react'
-import {NumberInput, required, SimpleForm, TextInput} from 'react-admin'
+import {FormTab, NumberInput, required, TabbedForm, TextInput} from 'react-admin'
 
+import {FlatpagePreview} from '@/components/Admin/custom/FlatpagePreview'
 import {MyCreate} from '@/components/Admin/custom/MyCreate'
 import {SitesCheckboxInput} from '@/components/Admin/custom/SitesCheckboxInput'
 
 export const FlatpageCreate: FC = () => (
   <MyCreate>
-    <SimpleForm>
-      <NumberInput source="id" fullWidth disabled />
-      <TextInput source="url" fullWidth validate={required()} />
-      <TextInput source="title" fullWidth validate={required()} />
-      <TextInput source="content" multiline fullWidth validate={required()} />
-      <SitesCheckboxInput source="sites" validate={required()} />
-    </SimpleForm>
+    <TabbedForm>
+      <FormTab label="general">
+        <NumberInput source="id" fullWidth disabled />
+        <TextInput source="url" fullWidth validate={required()} />
+        <TextInput source="title" fullWidth validate={required()} />
+        <TextInput source="content" multiline fullWidth validate={required()} />
+        <SitesCheckboxInput source="sites" validate={required()} />
+      </FormTab>
+      <FormTab label="preview">
+        <FlatpagePreview />
+      </FormTab>
+    </TabbedForm>
   </MyCreate>
 )

--- a/src/components/Admin/resources/base/flat-page/FlatpageEdit.tsx
+++ b/src/components/Admin/resources/base/flat-page/FlatpageEdit.tsx
@@ -1,17 +1,23 @@
 import {FC} from 'react'
-import {NumberInput, required, SimpleForm, TextInput} from 'react-admin'
+import {FormTab, NumberInput, required, TabbedForm, TextInput} from 'react-admin'
 
+import {FlatpagePreview} from '@/components/Admin/custom/FlatpagePreview'
 import {MyEdit} from '@/components/Admin/custom/MyEdit'
 import {SitesCheckboxInput} from '@/components/Admin/custom/SitesCheckboxInput'
 
 export const FlatpageEdit: FC = () => (
   <MyEdit>
-    <SimpleForm>
-      <NumberInput source="id" fullWidth disabled />
-      <TextInput source="url" fullWidth validate={required()} />
-      <TextInput source="title" fullWidth validate={required()} />
-      <TextInput source="content" multiline fullWidth validate={required()} />
-      <SitesCheckboxInput source="sites" validate={required()} />
-    </SimpleForm>
+    <TabbedForm>
+      <FormTab label="general">
+        <NumberInput source="id" fullWidth disabled />
+        <TextInput source="url" fullWidth validate={required()} />
+        <TextInput source="title" fullWidth validate={required()} />
+        <TextInput source="content" multiline fullWidth validate={required()} />
+        <SitesCheckboxInput source="sites" validate={required()} />
+      </FormTab>
+      <FormTab label="preview">
+        <FlatpagePreview />
+      </FormTab>
+    </TabbedForm>
   </MyEdit>
 )

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -49,6 +49,7 @@ declare module '@mui/material/Typography' {
 export const font = Poppins({
   subsets: ['latin'],
   weight: ['300', '400', '600', '700', '800'],
+  display: 'swap',
 })
 
 const _theme = createTheme({


### PR DESCRIPTION
fixes #259 

### flatpage preview

<img width="816" alt="image" src="https://github.com/ZdruzenieSTROM/webstrom-frontend/assets/6044119/7f390953-77a0-4080-9663-ceb91d434274">

### fixed post preview

collapsed:
<img width="511" alt="image" src="https://github.com/ZdruzenieSTROM/webstrom-frontend/assets/6044119/30284744-0080-4a36-9f1d-fa0479005b83">

expanded:
<img width="595" alt="image" src="https://github.com/ZdruzenieSTROM/webstrom-frontend/assets/6044119/fca9df54-c212-4f8c-a6c9-ee657bf9fe4c">
