### PR TITLE
Fix: LoginForm.tsx incorrect registration link in login dialog.

### DIFF
--- a/src/components/PageLayout/LoginForm/LoginForm.tsx
+++ b/src/components/PageLayout/LoginForm/LoginForm.tsx
@@ -84,7 +84,7 @@ export const LoginForm: FC<LoginFormProps> = ({closeDialog}) => {
               <Button variant="button3" type="button" onClick={toggleForgottenDialog}>
                 Zabudol som heslo
               </Button>
-              <Link variant="button3" href={`${seminar}/registracia`}>
+              <Link variant="button3" href={`/${seminar}/registracia`}>
                 Chcem sa registrovať
               </Link>
             </Stack>


### PR DESCRIPTION
Without / at the start, it redirects relatively e. g. from /matik/akcie/lomihlav to /matik/akcie/lomihlav/matik/registracia

Fixes #399 