### PR TITLE
turbopack - second try

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,35 +19,6 @@ const nextConfig: NextConfig = {
       },
     },
   },
-  // https://react-svgr.com/docs/next/
-  // skusili sme tento config zmazat, ale rozbilo to produkcny build. treba potom pozriet,
-  // ci turbopack este na prode nefunguje, alebo cim to je.
-  webpack(config) {
-    // Grab the existing rule that handles SVG imports
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fileLoaderRule = config.module.rules.find((rule: any) => rule.test?.test?.('.svg'))
-
-    config.module.rules.push(
-      // Reapply the existing rule, but only for svg imports ending in ?url
-      {
-        ...fileLoaderRule,
-        test: /\.svg$/i,
-        resourceQuery: /url/, // *.svg?url
-      },
-      // Convert all other *.svg imports to React components
-      {
-        test: /\.svg$/i,
-        issuer: /\.[jt]sx?$/,
-        resourceQuery: {not: /url/}, // exclude if *.svg?url
-        use: ['@svgr/webpack'],
-      },
-    )
-
-    // Modify the file loader rule to ignore *.svg, since we have it handled now.
-    fileLoaderRule.exclude = /\.svg$/i
-
-    return config
-  },
   reactStrictMode: true,
   // typecheck aj eslint pustame v CI pred buildom osobitne, nemusi ich pustat aj next
   typescript: {ignoreBuildErrors: true},

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "start": "next start",
-    "build": "next build",
+    "build": "next build --turbopack",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest"


### PR DESCRIPTION
Turbopack pre build je vlastne alpha 😄 alee... why not, if it works 😄 
https://nextjs.org/docs/app/api-reference/turbopack

bundle size je trochu vyssi (je to expected, este robia na optimalizaciach).

<details>
<summary>before:</summary>

```
➜  webstrom git:(turbopack-production) time y build
➤ YN0000: executing [build]: next build
   ▲ Next.js 15.3.2
   - Environments: .env

   Skipping validation of types
   Skipping linting
   Creating an optimized production build ...
 ✓ Compiled successfully in 14.0s
 ✓ Collecting page data    
 ✓ Generating static pages (4/4)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (pages)                                      Size  First Load JS    
┌ ○ /                                           1.48 kB         175 kB
├   /_app                                           0 B         169 kB
├ ○ /404                                          195 B         169 kB
├ ○ /admin                                      1.84 kB         171 kB
├ ƒ /malynar                                    1.39 kB         377 kB
├ ƒ /malynar/[page]                             1.02 kB         408 kB
├ ƒ /malynar/admin/opravit-ulohu/[[...params]]    347 B         431 kB
├ ƒ /malynar/admin/opravovanie/[[...params]]      332 B         271 kB
├ ƒ /malynar/akcie/[[...params]]                2.72 kB         431 kB
├ ƒ /malynar/archiv/[[...params]]                 925 B         231 kB
├ ƒ /malynar/profil                             1.75 kB         232 kB
├ ƒ /malynar/profil/uprava                      2.85 kB         246 kB
├ ƒ /malynar/registracia                          315 B         247 kB
├ ƒ /malynar/reset-password/[...resetToken]     1.17 kB         231 kB
├ ƒ /malynar/verify-email/[verificationKey]       925 B         231 kB
├ ƒ /malynar/vysledky/[[...params]]             1.56 kB         235 kB
├ ƒ /malynar/zadania/[[...params]]                343 B         456 kB
├ ƒ /matik                                      1.39 kB         377 kB
├ ƒ /matik/[page]                               1.01 kB         408 kB
├ ƒ /matik/admin/opravit-ulohu/[[...params]]      344 B         431 kB
├ ƒ /matik/admin/opravovanie/[[...params]]        332 B         271 kB
├ ƒ /matik/akcie/[[...params]]                  2.72 kB         431 kB
├ ƒ /matik/archiv/[[...params]]                   923 B         231 kB
├ ƒ /matik/profil                               1.75 kB         232 kB
├ ƒ /matik/profil/uprava                        2.85 kB         246 kB
├ ƒ /matik/registracia                            312 B         247 kB
├ ƒ /matik/reset-password/[...resetToken]       1.17 kB         231 kB
├ ƒ /matik/verify-email/[verificationKey]         922 B         231 kB
├ ƒ /matik/vysledky/[[...params]]               1.55 kB         235 kB
├ ƒ /matik/zadania/[[...params]]                  340 B         456 kB
├ ƒ /strom                                      1.37 kB         377 kB
├ ƒ /strom/[page]                                 991 B         408 kB
├ ƒ /strom/admin/opravit-ulohu/[[...params]]      259 B         431 kB
├ ƒ /strom/admin/opravovanie/[[...params]]        245 B         271 kB
├ ƒ /strom/akcie/[[...params]]                   2.7 kB         431 kB
├ ƒ /strom/archiv/[[...params]]                   894 B         231 kB
├ ƒ /strom/profil                               1.72 kB         232 kB
├ ƒ /strom/profil/uprava                        2.82 kB         246 kB
├ ƒ /strom/registracia                            229 B         247 kB
├ ƒ /strom/reset-password/[...resetToken]       1.15 kB         231 kB
├ ƒ /strom/verify-email/[verificationKey]         892 B         231 kB
├ ƒ /strom/vysledky/[[...params]]               1.52 kB         235 kB
└ ƒ /strom/zadania/[[...params]]                  254 B         456 kB
+ First Load JS shared by all                    170 kB
  ├ chunks/framework-d33e0fe36067854f.js        57.7 kB
  ├ chunks/main-91a3a57c92abed7b.js             34.2 kB
  ├ chunks/pages/_app-1b3bc1b6e482b56f.js       74.4 kB
  └ other shared chunks (total)                  3.2 kB

ƒ Middleware                                    33.5 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

yarn build  44.05s user 8.95s system 169% cpu 31.327 total
```

</details>


<details>
<summary>after:</summary>

```sh
➜  webstrom git:(turbopack-production) ✗ time y build
➤ YN0000: executing [build]: next build --turbopack
   ▲ Next.js 15.3.2 (Turbopack)
   - Environments: .env

   Skipping validation of types
   Skipping linting
   Creating an optimized production build ...
 ✓ Compiled successfully in 6.3s
 ✓ Collecting page data    
 ✓ Generating static pages (4/4)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (pages)                                      Size  First Load JS    
┌ ○ /                                           38.3 kB         233 kB
├   /_app                                           0 B         185 kB
├ ○ /404                                        11.5 kB         197 kB
├ ○ /admin                                      10.9 kB         196 kB
├ ƒ /malynar                                    7.18 kB         495 kB
├ ƒ /malynar/[page]                             6.59 kB         527 kB
├ ƒ /malynar/admin/opravit-ulohu/[[...params]]  4.82 kB         555 kB
├ ƒ /malynar/admin/opravovanie/[[...params]]     6.5 kB         385 kB
├ ƒ /malynar/akcie/[[...params]]                8.24 kB         553 kB
├ ƒ /malynar/archiv/[[...params]]               6.83 kB         337 kB
├ ƒ /malynar/profil                             7.72 kB         338 kB
├ ƒ /malynar/profil/uprava                      12.8 kB         354 kB
├ ƒ /malynar/registracia                        13.7 kB         354 kB
├ ƒ /malynar/reset-password/[...resetToken]     7.14 kB         336 kB
├ ƒ /malynar/verify-email/[verificationKey]     6.86 kB         337 kB
├ ƒ /malynar/vysledky/[[...params]]             10.8 kB         341 kB
├ ƒ /malynar/zadania/[[...params]]              12.2 kB         586 kB
├ ƒ /matik                                      7.18 kB         495 kB
├ ƒ /matik/[page]                               6.59 kB         527 kB
├ ƒ /matik/admin/opravit-ulohu/[[...params]]    4.82 kB         555 kB
├ ƒ /matik/admin/opravovanie/[[...params]]       6.5 kB         385 kB
├ ƒ /matik/akcie/[[...params]]                  8.24 kB         553 kB
├ ƒ /matik/archiv/[[...params]]                 6.83 kB         337 kB
├ ƒ /matik/profil                               7.72 kB         338 kB
├ ƒ /matik/profil/uprava                        12.8 kB         354 kB
├ ƒ /matik/registracia                          13.7 kB         354 kB
├ ƒ /matik/reset-password/[...resetToken]       7.14 kB         336 kB
├ ƒ /matik/verify-email/[verificationKey]       6.86 kB         337 kB
├ ƒ /matik/vysledky/[[...params]]               10.8 kB         341 kB
├ ƒ /matik/zadania/[[...params]]                12.2 kB         586 kB
├ ƒ /strom                                      7.15 kB         495 kB
├ ƒ /strom/[page]                               6.57 kB         527 kB
├ ƒ /strom/admin/opravit-ulohu/[[...params]]    4.75 kB         555 kB
├ ƒ /strom/admin/opravovanie/[[...params]]      6.45 kB         385 kB
├ ƒ /strom/akcie/[[...params]]                  8.22 kB         553 kB
├ ƒ /strom/archiv/[[...params]]                 6.81 kB         337 kB
├ ƒ /strom/profil                                7.7 kB         338 kB
├ ƒ /strom/profil/uprava                        12.8 kB         354 kB
├ ƒ /strom/registracia                          13.7 kB         354 kB
├ ƒ /strom/reset-password/[...resetToken]       7.12 kB         336 kB
├ ƒ /strom/verify-email/[verificationKey]       6.84 kB         337 kB
├ ƒ /strom/vysledky/[[...params]]               10.8 kB         341 kB
└ ƒ /strom/zadania/[[...params]]                12.2 kB         586 kB
+ First Load JS shared by all                    186 kB
  ├ chunks/6fa100ca6eaec7a1.js                  32.9 kB
  ├ chunks/9f0cf2c9b4db9338.js                    64 kB
  ├ chunks/aab8a7d7ce3d066f.js                  15.7 kB
  ├ chunks/e50f358fd17426b9.js                  31.2 kB
  └ chunks/e762ee8634edf400.js                  19.7 kB
  └ other shared chunks (total)                 22.4 kB

ƒ Middleware                                      51 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

 ⚠ Support for Turbopack builds is experimental. We don't recommend deploying mission-critical applications to production.

- Turbopack currently always builds production sourcemaps for the browser. This will include project sourcecode if deployed to production.
- It is expected that your bundle size might be different from `next build` with webpack. This will be improved as we work towards stability.
- This build is without disk caching; subsequent builds will become faster when disk caching becomes available.
- When comparing output to webpack builds, make sure to first clear the Next.js cache by deleting the `.next` directory.

Provide feedback for Turbopack builds at https://github.com/vercel/next.js/discussions/77721
yarn build  81.09s user 15.23s system 188% cpu 51.235 total
```

</details>

slubujem si od toho parkrat faster/lighter build 🤔 