### PR TITLE
fix: zatvor dropdown po vybere semestra/serie na mobile (#645)

### DIFF
--- a/src/components/SemesterPicker/Dropdown.tsx
+++ b/src/components/SemesterPicker/Dropdown.tsx
@@ -61,6 +61,7 @@ export const Dropdown: FC<{title: string; options: DropdownOption[]}> = ({title,
                 key={option.id}
                 component={Link}
                 href={option.link}
+                onClick={handleClose}
                 sx={{
                   bgcolor: colors.white,
                   color: colors.black,


### PR DESCRIPTION
Fixes #645 

Po kliknuti na semester/seriu v dropdown menu sa teraz automaticky zatvori dropdown. Problem bol hlavne viditelny na mobile, kde otvoreny dropdown mohol zakryvat dolezity obsah.

## Zmeny
- Pridany `onClick={handleClose}` handler na kazdu dropdown option
- Dropdown sa teraz zatvori hned po vybere moznosti, este pred navigaciou

----

keby som nemal GitHub MCP konfigurovane na pracu, Cursor by toto PR s tymto ^ popisom vytvoril sam 😄 