### PR TITLE
727: Fix absolute links in Footer

### DIFF
--- a/src/components/PageLayout/Footer/Footer.tsx
+++ b/src/components/PageLayout/Footer/Footer.tsx
@@ -9,6 +9,8 @@ import {Loading} from '@/components/Loading/Loading'
 import {Logo} from '@/components/PageLayout/Footer/Logo'
 import {useSeminarInfo} from '@/utils/useSeminarInfo'
 
+const isRelativeLink = (href: string) => href.startsWith('/')
+
 export const Footer: FC = () => {
   const {seminar, seminarId} = useSeminarInfo()
 
@@ -36,7 +38,13 @@ export const Footer: FC = () => {
         <Stack direction="row" m={2} gap={2} justifyContent="center" sx={{flexWrap: 'wrap'}}>
           {menuItemsIsLoading && <Loading />}
           {menuItems.map((item) => (
-            <Link key={item.id} variant="button2" href={`/${seminar}${item.url}`} invertColors>
+            <Link
+              key={item.id}
+              variant="button2"
+              // itemy z BE su bud relativne k seminar URL alebo absolutne
+              href={isRelativeLink(item.url) ? `/${seminar}${item.url}` : item.url}
+              invertColors
+            >
               {item.caption}
             </Link>
           ))}


### PR DESCRIPTION
fixes #727 

before:
<img width="814" height="133" alt="image" src="https://github.com/user-attachments/assets/8b96c78f-df49-4667-9547-e04fcd12d78a" />


after:
<img width="772" height="133" alt="image" src="https://github.com/user-attachments/assets/0a4d6fea-466d-43f4-8db2-28ae973724b3" />
