### PR TITLE
735: RA preklik zo serie na ulohu

### DIFF
--- a/src/components/Admin/resources/competition/series/SeriesShow.tsx
+++ b/src/components/Admin/resources/competition/series/SeriesShow.tsx
@@ -28,7 +28,7 @@ export const SeriesShow: FC = () => (
       <Tab label="content.labels.problems">
         <SimpleShowLayout>
           <ArrayField source="problems">
-            <Datagrid>
+            <Datagrid rowClick={(id) => `/competition/problem/${id}/show`}>
               <TruncatedTextField source="text" maxTextWidth={100} expandable />
             </Datagrid>
           </ArrayField>


### PR DESCRIPTION
fix #735.

`Datagrid` by default naviguje na entry v ramci stranky, na ktorej si, takze to ide na https://strom.sk/admin#/competition/series/1054/show miesto https://strom.sk/admin#/competition/problems/1054/show