### PR TITLE
703: Add ErrorBoundary around page content

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import {Box, Button, Typography} from '@mui/material'
+import * as Sentry from '@sentry/nextjs'
+import type {FC, PropsWithChildren} from 'react'
+
+import {colors} from '@/theme/colors'
+
+const fallback = (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      gap: 2,
+      p: 2,
+      textAlign: 'center',
+      backgroundColor: colors.white,
+    }}
+  >
+    <Typography variant="h2">Niečo sa pokazilo.</Typography>
+    <Typography variant="body1">Skús obnoviť stránku.</Typography>
+    <Button variant="contained" onClick={() => window.location.reload()}>
+      Obnoviť
+    </Button>
+  </Box>
+)
+
+// Sentry.ErrorBoundary reports caught errors via Sentry.captureException automatically.
+export const ErrorBoundary: FC<PropsWithChildren> = ({children}) => (
+  <Sentry.ErrorBoundary fallback={fallback}>{children}</Sentry.ErrorBoundary>
+)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -38,8 +38,8 @@ const MyApp: FC<AppProps<PageProps>> = ({Component, pageProps}) => {
                 <BannerAnimationContainer.Provider>
                   <ThemeProvider theme={theme}>
                     <CssBaseline />
-                    <AlertBox />
                     <ErrorBoundary>
+                      <AlertBox />
                       <Component {...pageProps} />
                     </ErrorBoundary>
                   </ThemeProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import {FC} from 'react'
 import {CookiesProvider} from 'react-cookie'
 
 import {AlertBox} from '@/components/Alert/AlertBox'
+import {ErrorBoundary} from '@/components/ErrorBoundary/ErrorBoundary'
 import {theme} from '@/theme/theme'
 import {AlertContainer} from '@/utils/AlertContainer'
 import {AuthContainer} from '@/utils/AuthContainer'
@@ -38,7 +39,9 @@ const MyApp: FC<AppProps<PageProps>> = ({Component, pageProps}) => {
                   <ThemeProvider theme={theme}>
                     <CssBaseline />
                     <AlertBox />
-                    <Component {...pageProps} />
+                    <ErrorBoundary>
+                      <Component {...pageProps} />
+                    </ErrorBoundary>
                   </ThemeProvider>
                 </BannerAnimationContainer.Provider>
               </AuthContainer.Provider>


### PR DESCRIPTION
Closes #703. Stacked on top of #830.

## Summary
- Add `ErrorBoundary` component that wraps `Sentry.ErrorBoundary`, rendering a branded Slovak fallback ("Niečo sa pokazilo" / "Skús obnoviť stránku") with a reload button. Caught errors are auto-reported to Sentry via the underlying component
- Wrap `<Component>` inside `ThemeProvider` in `_app.tsx` so the fallback can use MUI primitives (`Typography` theme variants, `Button`, theme colors)
- Fallback uses `backgroundColor: colors.white` — normal pages get their white bg from `PageLayout`, but when the boundary kicks in the page isn't rendered, and the body's default black background would otherwise leave us black-on-black

## Scope notes
- Boundary is placed **inside** `ThemeProvider` deliberately: page components are the dominant crash surface, and a themed fallback is nicer. Provider-level crashes (above the boundary) still get reported to Sentry via the client SDK's global `window.onerror` / `unhandledrejection` handlers — only the UI falls back to Next.js's generic "Application error" line. Adding an outer plain-HTML boundary is deferred; revisit if real provider crashes show up in Sentry
- `_error.tsx` still renders `next/error`'s default (English "500 | Internal Server Error" / "404 | This page could not be found"). A branded `_error` page with proper 404/5xx copy is a separate UX ticket worth opening

## Test plan
- [x] `yarn tsc` passes
- [x] `yarn lint` passes (no new warnings from this change)
- [x] Manually triggered a client-side render crash — fallback renders with readable white-bg MUI content, Sentry dashboard captured the exception
- [ ] Once #830 merges, rebase onto master and re-run CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)