### PR TITLE
720: Open external links and documents in a new tab

### DIFF
--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -26,7 +26,7 @@ const GalleryButton: FC<{
   gallery: Gallery
 }> = ({gallery}) => {
   return (
-    <Link variant="button2" href={gallery.gallery_link} target="_blank">
+    <Link variant="button2" href={gallery.gallery_link}>
       {gallery.name}
     </Link>
   )
@@ -36,7 +36,7 @@ const PublicationButton: FC<{
   publication: Publication
 }> = ({publication}) => {
   return (
-    <Link variant="button2" href={publication.file} target="_blank">
+    <Link variant="button2" href={publication.file}>
       {publication.name}
     </Link>
   )

--- a/src/components/Clickable/InlineLink.tsx
+++ b/src/components/Clickable/InlineLink.tsx
@@ -15,7 +15,14 @@ export const InlineLink: FC<InlineLinkProps> = ({children, href, target, sx, tex
   const isExternal = isExternalLink(href)
 
   return (
-    <Box component={isExternal ? 'a' : NextLink} href={href ?? ''} target={target} prefetch={prefetch} sx={sx}>
+    <Box
+      component={isExternal ? 'a' : NextLink}
+      href={href ?? ''}
+      target={target ?? (isExternal ? '_blank' : undefined)}
+      rel={isExternal ? 'noreferrer' : undefined}
+      prefetch={prefetch}
+      sx={sx}
+    >
       <Typography variant="inlineLink" sx={textSx}>
         {children}
       </Typography>

--- a/src/components/Clickable/Link.tsx
+++ b/src/components/Clickable/Link.tsx
@@ -61,7 +61,8 @@ export const Link: FC<LinkProps> = ({
     <Box
       component={isExternal ? 'a' : NextLink}
       href={href ?? ''}
-      target={target}
+      target={target ?? (isExternal ? '_blank' : undefined)}
+      rel={isExternal ? 'noreferrer' : undefined}
       prefetch={prefetch}
       onClick={(e) => e.stopPropagation()}
       sx={{

--- a/src/components/Clickable/isExternalLink.ts
+++ b/src/components/Clickable/isExternalLink.ts
@@ -3,7 +3,6 @@
 // inak aj pri `false` sa stale prefetchne pri hoveri, co je acceptable.
 export const isExternalLink = (href?: string) => {
   if (!href) return false
-
-  const isMedia = href.startsWith('/media')
-  return isMedia
+  if (href.startsWith('/media') || href.startsWith('/api/')) return true
+  return /^([a-z][\d+.a-z-]*:|\/\/)/i.test(href)
 }

--- a/src/components/CompetitionPage/CompetitionPage.tsx
+++ b/src/components/CompetitionPage/CompetitionPage.tsx
@@ -96,26 +96,26 @@ export const CompetitionPage: FC<CompetitionPageProps> = ({
               </Grid>
               <Grid size={2} display="flex" justifyContent="end">
                 {firstGallery ? (
-                  <Link variant="button2" href={firstGallery.gallery_link} target="_blank">
+                  <Link variant="button2" href={firstGallery.gallery_link}>
                     {firstGallery.name}
                   </Link>
                 ) : null}
               </Grid>
               <Grid size={2} display="flex" justifyContent="end">
                 {results && (
-                  <Link variant="button2" key={results.id} href={results.file} target="_blank">
+                  <Link variant="button2" key={results.id} href={results.file}>
                     {PublicationTypes.RESULTS.display_name}
                   </Link>
                 )}
               </Grid>
               <Grid size={2} display="flex" justifyContent="end">
                 {solutions ? (
-                  <Link variant="button2" key={solutions.id} href={solutions.file} target="_blank">
+                  <Link variant="button2" key={solutions.id} href={solutions.file}>
                     {PublicationTypes.SOLUTIONS.display_name}
                   </Link>
                 ) : (
                   problems && (
-                    <Link variant="button2" key={problems.id} href={problems.file} target="_blank">
+                    <Link variant="button2" key={problems.id} href={problems.file}>
                       {PublicationTypes.PROBLEMS.display_name}
                     </Link>
                   )

--- a/src/components/CompetitionPage/UpcomingOrCurrentEventInfo.tsx
+++ b/src/components/CompetitionPage/UpcomingOrCurrentEventInfo.tsx
@@ -47,7 +47,7 @@ export const UpcomingOrCurrentEventInfo: FC<{event: Event; name: string; shortNa
       </Typography>
       <Stack direction="row" sx={{justifyContent: 'end', gap: {xs: 1, sm: 2}}}>
         {invitationFile && (
-          <Link variant="button2" href={invitationFile.file ?? undefined} target="_blank">
+          <Link variant="button2" href={invitationFile.file ?? undefined}>
             Pozvánka
           </Link>
         )}

--- a/src/components/PageLayout/Footer/Logo.tsx
+++ b/src/components/PageLayout/Footer/Logo.tsx
@@ -32,7 +32,13 @@ export const Logo: FC<ILogo> = ({name, image, url}) => {
   const isExternal = isExternalLink(trimmedUrl)
 
   return (
-    <Box component={isExternal ? 'a' : NextLink} href={trimmedUrl} sx={{display: 'inline-flex'}}>
+    <Box
+      component={isExternal ? 'a' : NextLink}
+      href={trimmedUrl}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noreferrer' : undefined}
+      sx={{display: 'inline-flex'}}
+    >
       {imageElement}
     </Box>
   )

--- a/src/components/Problems/Problem.tsx
+++ b/src/components/Problems/Problem.tsx
@@ -103,7 +103,7 @@ export const Problem: FC<{
           }}
         >
           {problem.solution_pdf && (
-            <Link href={problem.solution_pdf} target="_blank" variant="button2">
+            <Link href={problem.solution_pdf} variant="button2">
               vzorové riešenie
             </Link>
           )}
@@ -111,7 +111,6 @@ export const Problem: FC<{
             <>
               <Link
                 href={`/api/competition/problem/${problem.id}/my-solution`}
-                target="_blank"
                 disabled={!problem.submitted}
                 variant="button2"
               >
@@ -130,7 +129,6 @@ export const Problem: FC<{
               </Link>
               <Link
                 href={`/api/competition/problem/${problem.id}/corrected-solution`}
-                target="_blank"
                 disabled={!problem.submitted?.corrected_solution}
                 variant="button2"
               >

--- a/src/components/PublicationUploader/PublicationUploader.tsx
+++ b/src/components/PublicationUploader/PublicationUploader.tsx
@@ -33,7 +33,7 @@ export const PublicationUploader: FC<PublicationUploaderProps> = ({semesterId, o
     <Stack direction="row" gap={2} alignItems="center">
       <Typography variant="body1">{order}. Časopis:</Typography>
       {publication && (
-        <Link variant="button2" href={publication.file} target="_blank">
+        <Link variant="button2" href={publication.file}>
           {publication.name}
         </Link>
       )}


### PR DESCRIPTION
Closes #720.

## Summary
- Broaden `isExternalLink` to cover real external URLs (`http(s)://`, `mailto:`, `tel:`, protocol-relative `//`) and `/api/...` backend file endpoints, in addition to the existing `/media/...`. Preserves the original Next.js prefetch rationale comment
- `Link`, `InlineLink`, and `Logo` auto-apply `target="_blank"` + `rel="noreferrer"` when `isExternalLink(href)` is true. Explicit `target` prop still wins (e.g. the `./gdpr` link in `RegisterForm` keeps its manual `target="_blank"` for an internal-but-new-tab case)
- Drop the now-redundant `target="_blank"` from 8 `<Link>` callsites whose hrefs are media files, gallery URLs, or `/api/...` downloads (`CompetitionPage`, `UpcomingOrCurrentEventInfo`, `Archive`, `Problem`, `PublicationUploader`)

## Approach
Implements the heuristic from [@rtrembecky's issue comment](https://github.com/ZdruzenieSTROM/webstrom-frontend/issues/720#issuecomment-): if a link starts with `/` and isn't a media/api file → same tab; otherwise → new tab. Uses the existing `isExternalLink` predicate (originally just for prefetch-skipping) as the single source of truth for "should open in new tab" as well — the two conditions line up.

## Scope notes
- Two callsites get a **new behavior**: the participants-export link in `SemesterAdministration` and the download-solutions link in `ProblemAdministration` previously had no `target` and now open in a new tab. Consistent with the issue's intent (file downloads), but flag if preferred otherwise
- Non-unified components (raw `<Box component="a">` in `ProblemAdministration`, `IconButton`, react-admin `FileField`) still carry their own `target="_blank"`. Out of scope here; they're not using our `Link`/`InlineLink`
- `.env.sentry-build-plugin` is untracked on the worktree — probably belongs in `.gitignore` but that's a separate concern

## Test plan
- [x] `yarn tsc` passes
- [x] `yarn lint` passes on touched files
- [ ] Manually verify: an external link (e.g. `ilovepdf.com` in `UploadProblemForm`) opens in a new tab
- [ ] Manually verify: a `/media/...` file (e.g. gallery/results PDF on competition page) opens in a new tab
- [ ] Manually verify: a `/api/...` download (my-solution / participants-export) opens in a new tab and downloads
- [ ] Manually verify: an internal Next.js route (menu items, "Podrobnosti", "Pravidlá") still opens in the same tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)