### PR TITLE
816: Pridaná stránka Kalendár

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,32 @@
+import {Box, Stack} from '@mui/material'
+import {FC} from 'react'
+
+import {Link} from '@/components/Clickable/Link'
+import {Markdown} from '@/components/Markdown/Markdown'
+
+const CALENDAR_ID = 'c_c12a88ba51a7b22813315d28200c49f62f8e37fd3e17ac31bc271b084192a9af@group.calendar.google.com'
+
+const embedSrc = `https://calendar.google.com/calendar/embed?src=${encodeURIComponent(
+  CALENDAR_ID,
+)}&ctz=Europe%2FBratislava&hl=sk&showTitle=0&showPrint=0&showCalendars=0&showTabs=1&color=%23000000`
+
+const subscribeSrc = `https://calendar.google.com/calendar/u/0/r?cid=${encodeURIComponent(CALENDAR_ID)}`
+
+export const Calendar: FC = () => (
+  <Stack gap={2}>
+    <Markdown content="V kalendári nájdeš všetky akcie, ktoré máme zatiaľ naplánované. Dátumy sa občas môžu meniť, tak ho priebežne sleduj alebo si ho pridaj do svojho Google Kalendára." />
+    <Box
+      component="iframe"
+      src={embedSrc}
+      title="Kalendár akcií"
+      sx={{
+        width: '100%',
+        height: {xs: 400, md: 700},
+        border: 0,
+      }}
+    />
+    <Link href={subscribeSrc} sx={{alignSelf: 'flex-start'}}>
+      Pridať kalendár do Google Kalendára
+    </Link>
+  </Stack>
+)

--- a/src/pages/malynar/kalendar.tsx
+++ b/src/pages/malynar/kalendar.tsx
@@ -1,0 +1,10 @@
+import {NextPage} from 'next'
+
+import Page, {getServerSideProps} from '../strom/kalendar'
+
+const KalendarPage: NextPage = () => {
+  return <Page />
+}
+
+export default KalendarPage
+export {getServerSideProps}

--- a/src/pages/matik/kalendar.tsx
+++ b/src/pages/matik/kalendar.tsx
@@ -1,0 +1,10 @@
+import {NextPage} from 'next'
+
+import Page, {getServerSideProps} from '../strom/kalendar'
+
+const KalendarPage: NextPage = () => {
+  return <Page />
+}
+
+export default KalendarPage
+export {getServerSideProps}

--- a/src/pages/strom/kalendar.tsx
+++ b/src/pages/strom/kalendar.tsx
@@ -1,0 +1,26 @@
+import {dehydrate, QueryClient} from '@tanstack/react-query'
+import {GetServerSideProps, NextPage} from 'next'
+
+import {commonQueries} from '@/api/commonQueries'
+import {Calendar} from '@/components/Calendar/Calendar'
+import {PageLayout} from '@/components/PageLayout/PageLayout'
+
+const KalendarPage: NextPage = () => (
+  <PageLayout title="Kalendár">
+    <Calendar />
+  </PageLayout>
+)
+
+export default KalendarPage
+
+export const getServerSideProps: GetServerSideProps = async ({resolvedUrl, req}) => {
+  const queryClient = new QueryClient()
+
+  await Promise.all(commonQueries(queryClient, resolvedUrl, req))
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
+}


### PR DESCRIPTION
## Zhrnutie
- Nová stránka `/{seminar}/kalendar/` s embedom Google Kalendára, pre všetky tri semináre (STROM, Matik, Malynár)
- Komponent `Calendar` (iframe embed + odkaz "Pridať kalendár do Google Kalendára"), kanonická implementácia pod `strom/`, matik a malynár reexportujú
- Closes #816

## Čo treba doriešiť v CMS
- Pridať menu item s `url: /kalendar/`, caption `Kalendár`, `in_menu: true` pre každý seminár. Frontend (`MenuMain` → `constructUrl`) z toho automaticky spraví `/{seminar}/kalendar/`

## Test plan
- [x] `/strom/kalendar/`, `/matik/kalendar/`, `/malynar/kalendar/` sa načítajú a zobrazia mesačný pohľad
  - https://test.strom.sk/strom/kalendar
- [ ] Odkaz "Pridať kalendár do Google Kalendára" otvorí dialóg v Google Calendar na prihlásenie odberu
- [ ] Mobilné zobrazenie (height 400px) vyzerá OK
- [ ] Po pridaní menu itemu v CMS sa "Kalendár" zobrazí v hlavnom menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)