### PR TITLE
843: Fix being unable to delete detail text from post

### DIFF
--- a/src/components/Admin/resources/cms/post/PostEdit.tsx
+++ b/src/components/Admin/resources/cms/post/PostEdit.tsx
@@ -8,7 +8,12 @@ import {PostPreview} from '@/components/Admin/custom/PostPreview'
 import {SitesCheckboxInput} from '@/components/Admin/custom/SitesCheckboxInput'
 
 export const PostEdit: FC = () => (
-  <MyEdit>
+  <MyEdit
+    transform={(record) => ({
+      ...record,
+      details: record.details ?? '',
+    })}
+  >
     <TabbedForm toolbar={<MyEditToolbar />}>
       <FormTab label="content.labels.general">
         <TextInput source="caption" validate={required()} />


### PR DESCRIPTION
normalizes empty string for saved text to ""

closes #843 