### PR TITLE
834: Fix SolutionShow crash by using NumberField

### DIFF
--- a/src/components/Admin/resources/competition/solution/SolutionShow.tsx
+++ b/src/components/Admin/resources/competition/solution/SolutionShow.tsx
@@ -1,6 +1,6 @@
 import type {FC} from 'react'
 import type {RaRecord} from 'react-admin'
-import {BooleanField, FunctionField, NumberInput, ReferenceField, SimpleShowLayout} from 'react-admin'
+import {BooleanField, FunctionField, NumberField, ReferenceField, SimpleShowLayout} from 'react-admin'
 
 import {DateTimeField} from '@/components/Admin/custom/DateTimeField'
 import {MyShowFileField} from '@/components/Admin/custom/file-handling/MyShowFileField'
@@ -18,7 +18,7 @@ export const SolutionShow: FC = () => (
         source="late_tag"
         render={(record) => record && <span>{record['late_tag']?.name}</span>}
       />
-      <NumberInput source="score" />
+      <NumberField source="score" />
       <BooleanField source="is_online" />
       <DateTimeField source="uploaded_at" />
     </SimpleShowLayout>


### PR DESCRIPTION
Closes #834.

## Summary
- `SolutionShow` rendered a `NumberInput` for `score`, which calls `useController` from react-hook-form and needs a form context. `SimpleShowLayout` doesn't provide one, so visiting `/admin#/competition/solution/:id/show` threw `Cannot read properties of null (reading 'control')`.
- Replaced it with `NumberField`, matching every other `Show` view in the codebase.

## Test plan
- [x] Open `/admin#/competition/solution/1361/show` — page renders without the runtime error.