### PR TITLE
824: Lepšie chybové hlášky v RA

### DIFF
--- a/src/components/Admin/dataProvider.ts
+++ b/src/components/Admin/dataProvider.ts
@@ -1,8 +1,9 @@
-import {isAxiosError} from 'axios'
 import {stringify} from 'querystring'
-import {DataProvider, FilterPayload, PaginationPayload, /* PaginationPayload, */ SortPayload} from 'react-admin'
+import {DataProvider, FilterPayload, PaginationPayload, SortPayload} from 'react-admin'
 
 import {apiAxios} from '@/api/apiAxios'
+
+import {toHttpError} from './parseError'
 
 const getFilterQuery = ({q, ...otherSearchParams}: FilterPayload) => ({
   ...otherSearchParams,
@@ -14,27 +15,6 @@ const getPaginationQuery = ({page, perPage}: PaginationPayload) => ({
   offset: (page - 1) * perPage,
   limit: perPage,
 })
-
-/* field errors by mali byt zachytene uz FE validaciou, dumpujem do 'Nastala neznáma chyba' */
-const parseError = (error: unknown) => {
-  // povacsine matchuje `mutations.onError` v `_app.tsx`
-  if (isAxiosError(error)) {
-    const data = error.response?.data as unknown
-    if (typeof data === 'object' && data) {
-      const detail = 'detail' in data && data.detail
-      if (typeof detail === 'string') return detail
-
-      const nonFieldErrors = 'non_field_errors' in data && data.non_field_errors
-      const nonFieldErrorsUnknown = Array.isArray(nonFieldErrors) ? (nonFieldErrors as unknown[]) : []
-      const nonFieldErrorsJoined = nonFieldErrorsUnknown.every((e) => typeof e === 'string')
-        ? nonFieldErrorsUnknown.join('\n')
-        : ''
-      if (nonFieldErrorsJoined) return nonFieldErrorsJoined
-    }
-  }
-
-  return 'Nastala neznáma chyba'
-}
 
 // skopirovane a dost upravene z https://github.com/bmihelac/ra-data-django-rest-framework/blob/master/src/index.ts
 export const dataProvider: DataProvider = {
@@ -64,7 +44,7 @@ export const dataProvider: DataProvider = {
         },
       }
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   getOne: async (resource, params) => {
@@ -72,7 +52,7 @@ export const dataProvider: DataProvider = {
       const {data} = await apiAxios.get(`/${resource}/${params.id}`)
       return {data}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   getMany: async (resource, params) => {
@@ -80,7 +60,7 @@ export const dataProvider: DataProvider = {
       const data = await Promise.all(params.ids.map((id) => apiAxios.get(`/${resource}/${id}`)))
       return {data: data.map(({data}) => data)}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   // TODO: ak budeme pouzivat tuto funkciu, upravime podla getList (pagination, sort, filter). uprimne este neviem, pri com sa pouziva
@@ -96,7 +76,7 @@ export const dataProvider: DataProvider = {
         total: data.length,
       }
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   update: async (resource, params) => {
@@ -110,7 +90,7 @@ export const dataProvider: DataProvider = {
       const {data} = await apiAxios.patch(`/${resource}/${id}`, body)
       return {data}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   updateMany: async (resource, params) => {
@@ -118,7 +98,7 @@ export const dataProvider: DataProvider = {
       const data = await Promise.all(params.ids.map((id) => apiAxios.patch(`/${resource}/${id}`, params.data)))
       return {data: data.map(({data}) => data)}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   create: async (resource, params) => {
@@ -130,7 +110,7 @@ export const dataProvider: DataProvider = {
       const {data} = await apiAxios.post(`/${resource}`, body)
       return {data}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   delete: async (resource, params) => {
@@ -138,7 +118,7 @@ export const dataProvider: DataProvider = {
       const {data} = await apiAxios.delete(`/${resource}/${params.id}`)
       return {data}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
   deleteMany: async (resource, params) => {
@@ -146,7 +126,7 @@ export const dataProvider: DataProvider = {
       const data = await Promise.all(params.ids.map((id) => apiAxios.delete(`/${resource}/${id}`)))
       return {data: data.map(({data}) => data.id)}
     } catch (error) {
-      throw new Error(parseError(error))
+      throw toHttpError(error)
     }
   },
 }

--- a/src/components/Admin/parseError.test.ts
+++ b/src/components/Admin/parseError.test.ts
@@ -1,0 +1,162 @@
+import {AxiosError, AxiosHeaders} from 'axios'
+import {describe, expect, it} from 'vitest'
+
+import {composeToastMessage, parseError} from './parseError'
+
+// AxiosError s nastavenou response (nepotrebujeme realny request, staci aby `isAxiosError` vratil true
+// a data/status boli citatelne).
+const axiosErrorWith = (status: number | undefined, data: unknown): AxiosError => {
+  const err = new AxiosError('test error')
+  if (status !== undefined) {
+    err.response = {status, data, statusText: '', headers: {}, config: {headers: new AxiosHeaders()}}
+  }
+  return err
+}
+
+describe(parseError, () => {
+  it('flat field error → single inline entry, empty top-level message', () => {
+    const err = axiosErrorWith(400, {school_year: ['Missing slash.']})
+
+    expect(parseError(err)).toStrictEqual({
+      message: '',
+      errors: {school_year: 'Missing slash.'},
+    })
+  })
+
+  it('nested field error (DRF nested serializer) → dot-path key', () => {
+    const err = axiosErrorWith(400, {registration_link: {url: ['Zadajte platnú URL adresu.']}})
+
+    expect(parseError(err)).toStrictEqual({
+      message: '',
+      errors: {'registration_link.url': 'Zadajte platnú URL adresu.'},
+    })
+  })
+
+  it('array-of-objects error (DRF list serializer) → indexed dot-path', () => {
+    const err = axiosErrorWith(400, {galleries: [{}, {name: ['Required.']}]})
+
+    expect(parseError(err)).toStrictEqual({
+      message: '',
+      errors: {'galleries.1.name': 'Required.'},
+    })
+  })
+
+  it('multiple messages on one field → joined with newline', () => {
+    const err = axiosErrorWith(400, {password: ['Too short.', 'Must contain a digit.']})
+
+    expect(parseError(err).errors).toStrictEqual({password: 'Too short.\nMust contain a digit.'})
+  })
+
+  it('top-level `detail` → becomes message, no field errors', () => {
+    const err = axiosErrorWith(403, {detail: 'Authentication credentials were not provided.'})
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Authentication credentials were not provided.',
+      errors: {},
+    })
+  })
+
+  it('top-level `non_field_errors` → becomes message, joined with newline', () => {
+    const err = axiosErrorWith(400, {non_field_errors: ['Začiatok musí byť pred koncom.', 'Dátum neplatný.']})
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Začiatok musí byť pred koncom.\nDátum neplatný.',
+      errors: {},
+    })
+  })
+
+  it('`non_field_errors` + field errors → both surface (message + inline)', () => {
+    const err = axiosErrorWith(400, {
+      non_field_errors: ['Kombinácia neplatná.'],
+      school_year: ['Missing slash.'],
+    })
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Kombinácia neplatná.',
+      errors: {school_year: 'Missing slash.'},
+    })
+  })
+
+  it('500 with no parseable body → fallback with status in message', () => {
+    const err = axiosErrorWith(500, '<html>Internal Server Error</html>')
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Nastala neznáma chyba (HTTP 500)',
+      errors: {},
+    })
+  })
+
+  it('502 with null body → fallback with status', () => {
+    const err = axiosErrorWith(502, null)
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Nastala neznáma chyba (HTTP 502)',
+      errors: {},
+    })
+  })
+
+  it('network error (no response) → plain fallback, no status suffix', () => {
+    const err = axiosErrorWith(undefined, undefined)
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Nastala neznáma chyba',
+      errors: {},
+    })
+  })
+
+  it('non-axios error → plain fallback', () => {
+    expect(parseError(new Error('oops'))).toStrictEqual({
+      message: 'Nastala neznáma chyba',
+      errors: {},
+    })
+  })
+
+  it('empty 400 body → fallback with status', () => {
+    const err = axiosErrorWith(400, {})
+
+    expect(parseError(err)).toStrictEqual({
+      message: 'Nastala neznáma chyba (HTTP 400)',
+      errors: {},
+    })
+  })
+})
+
+describe(composeToastMessage, () => {
+  it('only top-level message → shown as-is, no bullets', () => {
+    expect(composeToastMessage({message: 'Nemáš oprávnenie.', errors: {}})).toBe('Nemáš oprávnenie.')
+  })
+
+  it('only field errors → each on a bulleted line prefixed with its dot-path', () => {
+    expect(
+      composeToastMessage({
+        message: '',
+        errors: {
+          'registration_link.url': 'Zadajte platnú URL adresu.',
+          school_year: 'Missing slash.',
+        },
+      }),
+    ).toBe('• registration_link.url: Zadajte platnú URL adresu.\n• school_year: Missing slash.')
+  })
+
+  it('top-level + field errors → top-level on top (no bullet, no path), fields bulleted below', () => {
+    expect(
+      composeToastMessage({
+        message: 'Kombinácia neplatná.',
+        errors: {school_year: 'Missing slash.'},
+      }),
+    ).toBe('Kombinácia neplatná.\n• school_year: Missing slash.')
+  })
+
+  it('multi-line top-level message (joined non_field_errors) preserved before bullets', () => {
+    expect(
+      composeToastMessage({
+        message: 'Chyba 1.\nChyba 2.',
+        errors: {foo: 'bar'},
+      }),
+    ).toBe('Chyba 1.\nChyba 2.\n• foo: bar')
+  })
+
+  it('completely empty → safe fallback', () => {
+    expect(composeToastMessage({message: '', errors: {}})).toBe('Nastala neznáma chyba')
+  })
+})

--- a/src/components/Admin/parseError.ts
+++ b/src/components/Admin/parseError.ts
@@ -1,0 +1,83 @@
+import {isAxiosError} from 'axios'
+import {HttpError} from 'react-admin'
+
+export interface ParsedError {
+  /** Top-level message (DRF `detail` / `non_field_errors` / status-based fallback). Empty when only field errors were parsed. */
+  message: string
+  /** Field errors keyed by RHF dot-path (e.g. `registration_link.url`, `galleries.1.name`). */
+  errors: Record<string, string>
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const joinStringArray = (value: unknown): string | null => {
+  if (!Array.isArray(value)) return null
+  if (!value.every((e) => typeof e === 'string')) return null
+  return value.join('\n')
+}
+
+// DRF moze vratit field errors vnorene (napr. {registration_link: {url: ["..."]}}) alebo v poli
+// objektov (napr. {galleries: [{}, {name: ["..."]}]}). Splostujeme na dot-path aby RHF vedel
+// priradit chyby k policam.
+const flattenFieldErrors = (data: unknown, prefix: string, out: Record<string, string>): void => {
+  const joined = joinStringArray(data)
+  if (joined !== null) {
+    if (prefix) out[prefix] = joined
+    return
+  }
+
+  if (isPlainObject(data)) {
+    for (const [key, value] of Object.entries(data)) {
+      if (!prefix && (key === 'detail' || key === 'non_field_errors')) continue
+      flattenFieldErrors(value, prefix ? `${prefix}.${key}` : key, out)
+    }
+    return
+  }
+
+  if (Array.isArray(data)) {
+    for (const [i, item] of data.entries()) {
+      if (isPlainObject(item) && Object.keys(item).length > 0) {
+        flattenFieldErrors(item, prefix ? `${prefix}.${i}` : String(i), out)
+      }
+    }
+  }
+}
+
+export const parseError = (error: unknown): ParsedError => {
+  const errors: Record<string, string> = {}
+  const status = isAxiosError(error) ? error.response?.status : undefined
+
+  if (isAxiosError(error) && isPlainObject(error.response?.data)) {
+    const data = error.response.data
+    flattenFieldErrors(data, '', errors)
+
+    const detail = typeof data.detail === 'string' ? data.detail : ''
+    const nonFieldJoined = joinStringArray(data.non_field_errors) ?? ''
+    const topLevelMessage = detail || nonFieldJoined
+    if (topLevelMessage) return {message: topLevelMessage, errors}
+    if (Object.keys(errors).length > 0) return {message: '', errors}
+  }
+
+  const suffix = status ? ` (HTTP ${status})` : ''
+  return {message: `Nastala neznáma chyba${suffix}`, errors}
+}
+
+/** Compose a user-facing toast string from a parsed error. Top-level message first (unbulleted,
+ *  no path — top-level messages don't belong to any field), each field error on its own bulleted
+ *  line prefixed with its dot-path so the user knows which field it refers to — important when
+ *  the field is hidden, renamed, or otherwise not visibly bound to an inline error. */
+export const composeToastMessage = ({message, errors}: ParsedError): string => {
+  const bullets = Object.entries(errors).map(([path, m]) => `• ${path}: ${m}`)
+  return [message, ...bullets].filter(Boolean).join('\n') || 'Nastala neznáma chyba'
+}
+
+export const toHttpError = (error: unknown): HttpError => {
+  const parsed = parseError(error)
+  const toast = composeToastMessage(parsed)
+  const status = isAxiosError(error) ? (error.response?.status ?? 0) : 0
+  // `root.serverError` je specialna cesta, ktoru `useNotifyIsFormInvalid` v react-admin cita pre toast
+  // namiesto generickej `ra.message.invalid_form` hlasky. Takto nasa kompozovana sprava (top-level +
+  // bullet per field) skonci v notifikacii aj ked RA inak nasu `message` pri form submite ignoruje.
+  return new HttpError(toast, status, {errors: {...parsed.errors, root: {serverError: toast}}})
+}

--- a/src/components/Admin/resources/competition/event/EventCreate.tsx
+++ b/src/components/Admin/resources/competition/event/EventCreate.tsx
@@ -39,7 +39,7 @@ export const EventCreate: FC = () => {
             <TextInput
               source="registration_link.url"
               validate={required()}
-              helperText="Zadávajte v tvare https://prihlasky.strom.sk/xxx"
+              helperText="Zadávaj v tvare https://prihlasky.strom.sk/xxx"
             />
             <MyDateTimeInput source="registration_link.start" validate={required()} />
             <MyDateTimeInput source="registration_link.end" validate={required()} />

--- a/src/components/Admin/resources/competition/event/EventEdit.tsx
+++ b/src/components/Admin/resources/competition/event/EventEdit.tsx
@@ -42,7 +42,7 @@ export const EventEdit: FC = () => {
             <TextInput
               source="registration_link.url"
               validate={required()}
-              helperText="Zadávajte v tvare https://prihlasky.strom.sk/xxx"
+              helperText="Zadávaj v tvare https://prihlasky.strom.sk/xxx"
             />
             <MyDateTimeInput source="registration_link.start" validate={required()} />
             <MyDateTimeInput source="registration_link.end" validate={required()} />

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -185,7 +185,7 @@ export const RegisterForm: FC = () => {
             Vyplnením a odoslaním registrácie beriem na vedomie, že moje osobné údaje budú spracované v súlade so
             zákonom o ochrane osobných údajov. Bližšie informácie
             <Link href={`./gdpr`} target="_blank">
-              nájdete tu
+              nájdeš tu
             </Link>
             .
           </Typography>


### PR DESCRIPTION
Closes #824.

Disclaimer: nenapisal som ani riadok kodu. ale bolo to iterovane a testovane a dava mi to zmysel

## Summary
- dataProvider parses DRF error responses (flat / nested / array-of-objects) and surfaces field errors inline on the matching react-admin form inputs (`registration_link.url`, `galleries.1.name`, …) instead of swallowing everything into a generic "Nastala neznáma chyba".
- Error toast now lists all backend errors as bullets, with the top-level `detail` / `non_field_errors` message unbulleted on top when present. This is achieved by injecting `root.serverError` into `body.errors`, which RA's `useNotifyIsFormInvalid` reads in preference to the canned `ra.message.invalid_form`.
- Fallback toast includes the HTTP status when the body isn't parseable (e.g. `"Nastala neznáma chyba (HTTP 500)"`).
- Parsing lives in `src/components/Admin/parseError.ts` with example-driven tests.
- Side quest: three FE-authored Slovak strings switched to `tykanie` for consistency with the rest of the site ("Zadávaj" / "nájdeš", and an internal `Skontroluj`).

## Test plan
- [x] Bad URL in `registration_link.url` on `/admin#/competition/event/190` → inline error under the field + toast "• Zadajte platnú URL adresu."
- [x] 500 (valid URL but BE crashes) → toast "Nastala neznáma chyba (HTTP 500)"
- [x] `parseError` + `composeToastMessage` unit tests (17 cases) pass
- [x] `yarn lint` clean (only the pre-existing MenuMain warning)
- [x] `yarn tsc --noEmit` clean
- [ ] Reviewer: smoke-test a `detail` case (e.g. auth/permission error) — should show the raw DRF message
- [ ] Reviewer: smoke-test a `non_field_errors` case — should show at the top of the toast with field errors bulleted below

<img width="1200" height="1107" alt="toast-400-with-path" src="https://github.com/user-attachments/assets/f19c1879-cc7e-4e18-9692-bcdd74ebfddb" />

<img width="1200" height="1107" alt="toast-400-max-length" src="https://github.com/user-attachments/assets/0f120de1-4940-49b4-851c-72578a1b3511" />

<img width="1200" height="1107" alt="toast-400-array-path" src="https://github.com/user-attachments/assets/1f85f829-6c90-4e24-8dfb-542576c4a049" />
