### PR TITLE
Pre-filter Admin Competition/Event lists by type

### DIFF
--- a/src/components/Admin/custom/list-filtering/CompetitionFilterSection.tsx
+++ b/src/components/Admin/custom/list-filtering/CompetitionFilterSection.tsx
@@ -1,11 +1,15 @@
 import {FC} from 'react'
-import {AutocompleteInput, FilterListSection, FilterLiveForm, ReferenceInput} from 'react-admin'
+import {AutocompleteInput, FilterListSection, FilterLiveForm, RaRecord, ReferenceInput} from 'react-admin'
 
-export const CompetitionFilterSection: FC = () => {
+type Props = {
+  filter?: Partial<RaRecord>
+}
+
+export const CompetitionFilterSection: FC<Props> = ({filter}) => {
   return (
     <FilterListSection label="Competition" icon={null}>
       <FilterLiveForm>
-        <ReferenceInput source="competition" reference="competition/competition">
+        <ReferenceInput source="competition" reference="competition/competition" filter={filter}>
           <AutocompleteInput helperText={false} />
         </ReferenceInput>
       </FilterLiveForm>

--- a/src/components/Admin/resources/competition/competition/CompetitionList.tsx
+++ b/src/components/Admin/resources/competition/competition/CompetitionList.tsx
@@ -6,7 +6,7 @@ import {SitesArrayField} from '@/components/Admin/custom/SitesArrayField'
 import {TruncatedTextField} from '@/components/Admin/custom/TruncatedTextField'
 
 export const CompetitionList: FC = () => (
-  <List aside={<CompetitionListFilters />}>
+  <List aside={<CompetitionListFilters />} filter={{competition_type: 0}}>
     <Datagrid>
       <TextField source="name" />
       <TextField source="slug" sortable={false} />

--- a/src/components/Admin/resources/competition/event/EventCreate.tsx
+++ b/src/components/Admin/resources/competition/event/EventCreate.tsx
@@ -25,7 +25,7 @@ export const EventCreate: FC = () => {
         <TextInput source="school_year" helperText="napr. 2023/2024" validate={required()} />
         <MyDateTimeInput source="start" validate={required()} />
         <MyDateTimeInput source="end" validate={required()} />
-        <ReferenceInput source="competition" reference="competition/competition">
+        <ReferenceInput source="competition" reference="competition/competition" filter={{competition_type_exclude: 0}}>
           <SelectInput validate={required()} />
         </ReferenceInput>
         <TextInput source="location" />

--- a/src/components/Admin/resources/competition/event/EventEdit.tsx
+++ b/src/components/Admin/resources/competition/event/EventEdit.tsx
@@ -28,7 +28,7 @@ export const EventEdit: FC = () => {
         <TextInput source="school_year" helperText="napr. 2023/2024" validate={required()} />
         <MyDateTimeInput source="start" validate={required()} />
         <MyDateTimeInput source="end" validate={required()} />
-        <ReferenceInput source="competition" reference="competition/competition">
+        <ReferenceInput source="competition" reference="competition/competition" filter={{competition_type_exclude: 0}}>
           <SelectInput validate={required()} />
         </ReferenceInput>
         <TextInput source="location" />

--- a/src/components/Admin/resources/competition/event/EventList.tsx
+++ b/src/components/Admin/resources/competition/event/EventList.tsx
@@ -8,7 +8,7 @@ import {SeasonCodeFilterList} from '@/components/Admin/custom/list-filtering/Sea
 import {SeasonCodeField} from '@/components/Admin/custom/SeasonCodeField'
 
 export const EventList: FC = () => (
-  <List aside={<EventListFilters />}>
+  <List aside={<EventListFilters />} filter={{competition_type_exclude: 0}}>
     <Datagrid>
       <ReferenceField source="competition" reference="competition/competition" link={false} sortable={false} />
       <NumberField source="year" />

--- a/src/components/Admin/resources/competition/event/EventList.tsx
+++ b/src/components/Admin/resources/competition/event/EventList.tsx
@@ -31,7 +31,7 @@ export const EventList: FC = () => (
 // TODO: filtre a ordering podla https://github.com/ZdruzenieSTROM/webstrom-backend/pull/460/files#diff-148e08b739e60a78edfc1e546340f501840b75f1646afa58ee524ff82cfc061eR832-R838
 const EventListFilters: FC = () => (
   <FilterSidebar>
-    <CompetitionFilterSection />
+    <CompetitionFilterSection filter={{competition_type_exclude: 0}} />
 
     <SeasonCodeFilterList />
 

--- a/src/components/Admin/resources/competition/semester/SemesterCreate.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterCreate.tsx
@@ -19,7 +19,7 @@ import {seasonCodeStrings} from '../../../seasonCodeStrings'
 export const SemesterCreate: FC = () => (
   <MyCreate>
     <SimpleForm toolbar={<MyCreateToolbar />}>
-      <ReferenceInput source="competition" reference="competition/competition">
+      <ReferenceInput source="competition" reference="competition/competition" filter={{competition_type: 0}}>
         <SelectInput validate={required()} />
       </ReferenceInput>
       <NumberInput source="year" helperText="ročník súťaže, napr. 48" validate={required()} />

--- a/src/components/Admin/resources/competition/semester/SemesterEdit.tsx
+++ b/src/components/Admin/resources/competition/semester/SemesterEdit.tsx
@@ -29,7 +29,7 @@ export const SemesterEdit: FC = () => (
   >
     <TabbedForm toolbar={<MyEditToolbar />}>
       <FormTab label="content.labels.general">
-        <ReferenceInput source="competition" reference="competition/competition">
+        <ReferenceInput source="competition" reference="competition/competition" filter={{competition_type: 0}}>
           <SelectInput validate={required()} />
         </ReferenceInput>
         <NumberInput source="year" helperText="ročník súťaže, napr. 48" />


### PR DESCRIPTION
## Summary
Pre-filter Admin lists and Competition pickers by competition type, so admins don't have to wade through irrelevant records.

**Lists**
- `CompetitionList` → only seminars (`competition_type=0`)
- `EventList` → excludes seminars (`competition_type_exclude=0`)

**Competition pickers** (`ReferenceInput reference=\"competition/competition\"`)
- `EventCreate`, `EventEdit` → exclude seminars
- `SemesterCreate`, `SemesterEdit` → seminars only
- `CompetitionFilterSection` (used in Event list sidebar) now accepts a \`filter\` prop; Event list passes \`competition_type_exclude=0\`

## Dependency
Requires BE filters added in ZdruzenieSTROM/webstrom-backend#643:
- \`EventViewSet\`: \`competition_type\` / \`competition_type_exclude\`
- \`CompetitionViewSet\`: \`competition_type_exclude\` (for the dropdowns on Event Create/Edit)

The positive \`competition_type=<id>\` filter on \`CompetitionViewSet\` already exists; the seminars-only Semester pickers and \`CompetitionList\` work without the BE PR.

## Test plan
- [ ] \`/admin/#/competition/competition\` → GET \`?competition_type=0\`, lists only seminars
- [ ] \`/admin/#/competition/semester/create\` + \`/edit\` → Competition dropdown fetches \`?competition_type=0\`
- [ ] After BE#643:
  - \`/admin/#/competition/event\` → GET \`?competition_type_exclude=0\`, hides seminar events
  - \`/admin/#/competition/event/create\` + \`/edit\` → Competition dropdown fetches \`?competition_type_exclude=0\`
  - Event list sidebar Competition autocomplete fetches \`?competition_type_exclude=0\`