### PR TITLE
764: Rework Archive - group rows by year and restructure

### DIFF
--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -38,6 +38,14 @@ const getSeasonLabel = (eventSeason: number) => {
   return eventSeason === 0 ? 'zimný semester' : 'letný semester'
 }
 
+const getResultsUrl = (eventYear: number, eventSeason: number) => {
+  return `../poradie/${eventYear}/${getSeasonSlug(eventSeason)}`
+}
+
+const getProblemsUrl = (eventYear: number, eventSeason: number, seriesOrder: 1 | 2) => {
+  return `../zadania/${eventYear}/${getSeasonSlug(eventSeason)}/${seriesOrder}`
+}
+
 const getArchiveButtonSx = (disabled = false): SxProps<Theme> => {
   return {
     '.archive-row:hover &': {
@@ -55,12 +63,13 @@ const getArchiveButtonSx = (disabled = false): SxProps<Theme> => {
   }
 }
 
-const GalleryButton: FC<{
-  gallery: Gallery
-}> = ({gallery}) => {
+const ArchiveActionButton: FC<{
+  href: string
+  label: string
+}> = ({href, label}) => {
   return (
-    <Link variant="button2" href={gallery.gallery_link} sx={getArchiveButtonSx()}>
-      Fotky
+    <Link variant="button2" href={href} sx={getArchiveButtonSx()}>
+      {label}
     </Link>
   )
 }
@@ -111,33 +120,6 @@ const getYearGroups = (eventList: MyEvent[]): YearGroup[] => {
       ...group,
       events: group.events.toSorted((leftEvent, rightEvent) => leftEvent.season_code - rightEvent.season_code),
     }))
-}
-
-const ResultsButton: FC<{
-  eventYear: number
-  eventSeason: number
-}> = ({eventYear, eventSeason}) => {
-  const season = getSeasonSlug(eventSeason)
-  const url = `../poradie/${eventYear}/${season}`
-  return (
-    <Link variant="button2" href={url} sx={getArchiveButtonSx()}>
-      Poradie
-    </Link>
-  )
-}
-
-const ProblemsButton: FC<{
-  eventYear: number
-  eventSeason: number
-  seriesOrder: 1 | 2
-}> = ({eventYear, eventSeason, seriesOrder}) => {
-  const season = getSeasonSlug(eventSeason)
-  const url = `../zadania/${eventYear}/${season}/${seriesOrder}`
-  return (
-    <Link variant="button2" href={url} sx={getArchiveButtonSx()}>
-      Zadania
-    </Link>
-  )
 }
 
 const ArchiveRow: FC<{
@@ -212,19 +194,19 @@ export const Archive: FC = () => {
                   <Stack key={event.id} gap={0}>
                     <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
                       {seasonLeaflet && <PublicationButton publication={seasonLeaflet} label="Časopis" />}
-                      <ResultsButton eventYear={event.year} eventSeason={event.season_code} />
+                      <ArchiveActionButton href={getResultsUrl(event.year, event.season_code)} label="Poradie" />
                     </ArchiveRow>
                     <ArchiveRow label="1. séria" indented>
-                      <ProblemsButton eventYear={event.year} eventSeason={event.season_code} seriesOrder={1} />
+                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 1)} label="Zadania" />
                       <PublicationButton publication={firstSeriesLeaflet} label="Riešenia" />
                     </ArchiveRow>
                     <ArchiveRow label="2. séria" indented>
-                      <ProblemsButton eventYear={event.year} eventSeason={event.season_code} seriesOrder={2} />
+                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 2)} label="Zadania" />
                       <PublicationButton publication={secondSeriesLeaflet} label="Riešenia" />
                     </ArchiveRow>
                     {firstGallery && (
                       <ArchiveRow label="Sústredenie" indented>
-                        <GalleryButton gallery={firstGallery} />
+                        <ArchiveActionButton href={firstGallery.gallery_link} label="Fotky" />
                       </ArchiveRow>
                     )}
                   </Stack>

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -185,9 +185,10 @@ export const Archive: FC = () => {
     <Stack gap={1}>
       {eventListIsLoading && <Loading />}
 
-      {yearGroups.map((group) => (
+      {yearGroups.map((group, index) => (
         <Accordion
           key={group.year}
+          defaultExpanded={index === 0}
           disableGutters
           square={false}
           sx={{boxShadow: 'none', '&:before': {display: 'none'}}}
@@ -200,14 +201,14 @@ export const Archive: FC = () => {
             </Stack>
           </AccordionSummary>
           <AccordionDetails sx={{p: 0}}>
-            <Stack gap={2}>
+            <Stack gap={1}>
               {group.events.map((event) => {
                 const seasonLeaflet = getLeafletPublication(event, 1)
                 const firstSeriesLeaflet = getLeafletPublication(event, 2)
                 const secondSeriesLeaflet = getLeafletPublication(event, 3)
 
                 return (
-                  <Stack key={event.id} gap={1}>
+                  <Stack key={event.id} gap={0}>
                     <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
                       {seasonLeaflet && <PublicationButton publication={seasonLeaflet} label="Časopis" />}
                       <ResultsButton eventYear={event.year} eventSeason={event.season_code} />

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -60,7 +60,7 @@ const GalleryButton: FC<{
 }> = ({gallery}) => {
   return (
     <Link variant="button2" href={gallery.gallery_link} sx={getArchiveButtonSx()}>
-      {gallery.name}
+      Fotky
     </Link>
   )
 }
@@ -206,6 +206,7 @@ export const Archive: FC = () => {
                 const seasonLeaflet = getLeafletPublication(event, 1)
                 const firstSeriesLeaflet = getLeafletPublication(event, 2)
                 const secondSeriesLeaflet = getLeafletPublication(event, 3)
+                const firstGallery = event.galleries[0]
 
                 return (
                   <Stack key={event.id} gap={0}>
@@ -221,11 +222,9 @@ export const Archive: FC = () => {
                       <ProblemsButton eventYear={event.year} eventSeason={event.season_code} seriesOrder={2} />
                       <PublicationButton publication={secondSeriesLeaflet} label="Riešenia" />
                     </ArchiveRow>
-                    {event.galleries.length > 0 && (
+                    {firstGallery && (
                       <ArchiveRow label="Sústredenie" indented>
-                        {event.galleries.map((gallery) => (
-                          <GalleryButton key={gallery.id} gallery={gallery} />
-                        ))}
+                        <GalleryButton gallery={firstGallery} />
                       </ArchiveRow>
                     )}
                   </Stack>

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -1,9 +1,10 @@
 import {ExpandMore} from '@mui/icons-material'
-import {Accordion, AccordionDetails, AccordionSummary, Stack, Typography} from '@mui/material'
+import {Accordion, AccordionDetails, AccordionSummary, Stack, SxProps, Theme, Typography} from '@mui/material'
 import {useQuery} from '@tanstack/react-query'
 import {FC} from 'react'
 
 import {apiAxios} from '@/api/apiAxios'
+import {colors} from '@/theme/colors'
 import {Gallery} from '@/types/api/cms'
 import {Event, Publication, PublicationTypes} from '@/types/api/competition'
 import {useSeminarInfo} from '@/utils/useSeminarInfo'
@@ -37,11 +38,28 @@ const getSeasonLabel = (eventSeason: number) => {
   return eventSeason === 0 ? 'zimný semester' : 'letný semester'
 }
 
+const getArchiveButtonSx = (disabled = false): SxProps<Theme> => {
+  return {
+    '.archive-row:hover &': {
+      '--bgcolor': colors.black,
+      '--color': disabled ? colors.gray : colors.white,
+      bgcolor: colors.black,
+      color: disabled ? colors.gray : colors.white,
+    },
+    '.archive-row:hover &:hover': {
+      '--bgcolor': disabled ? colors.gray : colors.white,
+      '--color': disabled ? colors.white : colors.black,
+      bgcolor: disabled ? colors.gray : colors.white,
+      color: disabled ? colors.white : colors.black,
+    },
+  }
+}
+
 const GalleryButton: FC<{
   gallery: Gallery
 }> = ({gallery}) => {
   return (
-    <Link variant="button2" href={gallery.gallery_link}>
+    <Link variant="button2" href={gallery.gallery_link} sx={getArchiveButtonSx()}>
       {gallery.name}
     </Link>
   )
@@ -52,7 +70,12 @@ const PublicationButton: FC<{
   label?: string
 }> = ({publication, label}) => {
   return (
-    <Link variant="button2" disabled={!publication} href={publication?.file || '#'}>
+    <Link
+      variant="button2"
+      disabled={!publication}
+      href={publication?.file || '#'}
+      sx={getArchiveButtonSx(!publication)}
+    >
       {label ?? publication?.name}
     </Link>
   )
@@ -97,7 +120,7 @@ const ResultsButton: FC<{
   const season = getSeasonSlug(eventSeason)
   const url = `../poradie/${eventYear}/${season}`
   return (
-    <Link variant="button2" href={url}>
+    <Link variant="button2" href={url} sx={getArchiveButtonSx()}>
       Poradie
     </Link>
   )
@@ -111,7 +134,7 @@ const ProblemsButton: FC<{
   const season = getSeasonSlug(eventSeason)
   const url = `../zadania/${eventYear}/${season}/${seriesOrder}`
   return (
-    <Link variant="button2" href={url}>
+    <Link variant="button2" href={url} sx={getArchiveButtonSx()}>
       Zadania
     </Link>
   )
@@ -124,7 +147,22 @@ const ArchiveRow: FC<{
   gap?: number | string
 }> = ({label, children, indented = false, gap = 0.5}) => {
   return (
-    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1} sx={{pl: indented ? 2 : 0}}>
+    <Stack
+      className="archive-row"
+      direction="row"
+      justifyContent="space-between"
+      alignItems="flex-start"
+      gap={1}
+      sx={{
+        pl: indented ? 3 : 1,
+        pr: 1,
+        py: 0.5,
+        '&:hover': {
+          bgcolor: colors.black,
+          color: colors.white,
+        },
+      }}
+    >
       <Typography variant="h3">{label}</Typography>
       <Stack direction="row" flexWrap="wrap" justifyContent="flex-end" gap={gap}>
         {children}

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -1,11 +1,11 @@
 import {ExpandMore} from '@mui/icons-material'
-import {Accordion, AccordionDetails, AccordionSummary, Stack, SxProps, Typography} from '@mui/material'
+import {Accordion, AccordionDetails, AccordionSummary, Stack, Typography} from '@mui/material'
 import {useQuery} from '@tanstack/react-query'
 import {FC} from 'react'
 
 import {apiAxios} from '@/api/apiAxios'
 import {Gallery} from '@/types/api/cms'
-import {Event, Publication} from '@/types/api/competition'
+import {Event, Publication, PublicationTypes} from '@/types/api/competition'
 import {useSeminarInfo} from '@/utils/useSeminarInfo'
 
 import {Link} from '../Clickable/Link'
@@ -15,11 +15,26 @@ import {Loading} from '../Loading/Loading'
 type MyPublication = Publication & {
   name: string
 }
+
 type MyEvent = Omit<Event, 'publication_set'> & {
   year: number
   school_year: string
   publication_set: MyPublication[]
   galleries: Gallery[]
+}
+
+type YearGroup = {
+  year: number
+  schoolYear: string | null
+  events: MyEvent[]
+}
+
+const getSeasonSlug = (eventSeason: number) => {
+  return eventSeason === 0 ? 'zima' : 'leto'
+}
+
+const getSeasonLabel = (eventSeason: number) => {
+  return eventSeason === 0 ? 'zimný semester' : 'letný semester'
 }
 
 const GalleryButton: FC<{
@@ -33,24 +48,56 @@ const GalleryButton: FC<{
 }
 
 const PublicationButton: FC<{
-  publication: Publication
-}> = ({publication}) => {
+  publication?: Publication
+  label?: string
+}> = ({publication, label}) => {
   return (
-    <Link variant="button2" href={publication.file}>
-      {publication.name}
+    <Link variant="button2" disabled={!publication} href={publication?.file || '#'}>
+      {label ?? publication?.name}
     </Link>
   )
+}
+
+const getLeafletPublication = (event: MyEvent, order: number) => {
+  return event.publication_set.find(
+    (publication) => publication.publication_type === PublicationTypes.LEAFLET.id && publication.order === order,
+  )
+}
+
+const getYearGroups = (eventList: MyEvent[]): YearGroup[] => {
+  const groups = new Map<number, YearGroup>()
+
+  for (const event of eventList) {
+    const existingGroup = groups.get(event.year)
+
+    if (existingGroup) {
+      existingGroup.events.push(event)
+      continue
+    }
+
+    groups.set(event.year, {
+      year: event.year,
+      schoolYear: event.school_year,
+      events: [event],
+    })
+  }
+
+  return [...groups.values()]
+    .toSorted((leftGroup, rightGroup) => rightGroup.year - leftGroup.year)
+    .map((group) => ({
+      ...group,
+      events: group.events.toSorted((leftEvent, rightEvent) => leftEvent.season_code - rightEvent.season_code),
+    }))
 }
 
 const ResultsButton: FC<{
   eventYear: number
   eventSeason: number
-  sx?: SxProps
-}> = ({eventYear, eventSeason, sx}) => {
-  const season = eventSeason === 0 ? 'zima' : 'leto'
+}> = ({eventYear, eventSeason}) => {
+  const season = getSeasonSlug(eventSeason)
   const url = `../poradie/${eventYear}/${season}`
   return (
-    <Link variant="button2" href={url} sx={sx}>
+    <Link variant="button2" href={url}>
       Poradie
     </Link>
   )
@@ -59,22 +106,31 @@ const ResultsButton: FC<{
 const ProblemsButton: FC<{
   eventYear: number
   eventSeason: number
-  sx?: SxProps
-}> = ({eventYear, eventSeason, sx}) => {
-  const season = eventSeason === 0 ? 'zima' : 'leto'
-  const url = `../zadania/${eventYear}/${season}/1`
+  seriesOrder: 1 | 2
+}> = ({eventYear, eventSeason, seriesOrder}) => {
+  const season = getSeasonSlug(eventSeason)
+  const url = `../zadania/${eventYear}/${season}/${seriesOrder}`
   return (
-    <Link variant="button2" href={url} sx={sx}>
+    <Link variant="button2" href={url}>
       Zadania
     </Link>
   )
 }
 
-const showInSummary = {display: {xs: 'none', sm: 'flex', md: 'none', lg: 'flex'}}
-const showInDetails = {display: {xs: 'flex', sm: 'none', md: 'flex', lg: 'none'}}
-const alignEndInDetails = {
-  justifyContent: {sm: 'end', md: 'unset', lg: 'end'},
-  pr: {sm: '35px', md: 'unset', lg: '35px'},
+const ArchiveRow: FC<{
+  label: string
+  children: React.ReactNode
+  indented?: boolean
+  gap?: number | string
+}> = ({label, children, indented = false, gap = 0.5}) => {
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1} sx={{pl: indented ? 2 : 0}}>
+      <Typography variant="h3">{label}</Typography>
+      <Stack direction="row" flexWrap="wrap" justifyContent="flex-end" gap={gap}>
+        {children}
+      </Stack>
+    </Stack>
+  )
 }
 
 export const Archive: FC = () => {
@@ -85,32 +141,57 @@ export const Archive: FC = () => {
     queryFn: () => apiAxios.get<MyEvent[]>(`/competition/event/?competition=${seminarId}`),
   })
   const eventList = eventListData?.data ?? []
+  const yearGroups = getYearGroups(eventList)
 
   return (
     <Stack gap={1}>
       {eventListIsLoading && <Loading />}
 
-      {eventList.map((event) => (
-        <Accordion key={event.id} disableGutters square={false} sx={{boxShadow: 'none', '&:before': {display: 'none'}}}>
+      {yearGroups.map((group) => (
+        <Accordion
+          key={group.year}
+          disableGutters
+          square={false}
+          sx={{boxShadow: 'none', '&:before': {display: 'none'}}}
+        >
           <AccordionSummary expandIcon={<ExpandMore color="primary" fontSize="large" />} sx={{p: 0}}>
             <Stack direction="row" sx={{flexGrow: 1}}>
               <Typography variant="h2" sx={{flexGrow: 1}}>
-                {event.year + '. ročník ' + (event.season_code === 0 ? 'zimný' : 'letný') + ' semester'}
+                {group.year + '. ročník' + (group.schoolYear ? ` \u2013 ${group.schoolYear}` : '')}
               </Typography>
-              <ResultsButton eventYear={event.year} eventSeason={event.season_code} sx={showInSummary} />
-              <ProblemsButton eventYear={event.year} eventSeason={event.season_code} sx={showInSummary} />
             </Stack>
           </AccordionSummary>
           <AccordionDetails sx={{p: 0}}>
-            <Stack direction="row" sx={{flexWrap: 'wrap', rowGap: 0.5, ...alignEndInDetails}}>
-              <ResultsButton eventYear={event.year} eventSeason={event.season_code} sx={showInDetails} />
-              <ProblemsButton eventYear={event.year} eventSeason={event.season_code} sx={showInDetails} />
-              {event.publication_set.map((publication) => (
-                <PublicationButton key={publication.id} publication={publication} />
-              ))}
-              {event.galleries.map((gallery) => (
-                <GalleryButton key={gallery.id} gallery={gallery} />
-              ))}
+            <Stack gap={2}>
+              {group.events.map((event) => {
+                const seasonLeaflet = getLeafletPublication(event, 1)
+                const firstSeriesLeaflet = getLeafletPublication(event, 2)
+                const secondSeriesLeaflet = getLeafletPublication(event, 3)
+
+                return (
+                  <Stack key={event.id} gap={1}>
+                    <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
+                      {seasonLeaflet && <PublicationButton publication={seasonLeaflet} label="Časopis" />}
+                      <ResultsButton eventYear={event.year} eventSeason={event.season_code} />
+                    </ArchiveRow>
+                    <ArchiveRow label="1. séria" indented>
+                      <ProblemsButton eventYear={event.year} eventSeason={event.season_code} seriesOrder={1} />
+                      <PublicationButton publication={firstSeriesLeaflet} label="Riešenia" />
+                    </ArchiveRow>
+                    <ArchiveRow label="2. séria" indented>
+                      <ProblemsButton eventYear={event.year} eventSeason={event.season_code} seriesOrder={2} />
+                      <PublicationButton publication={secondSeriesLeaflet} label="Riešenia" />
+                    </ArchiveRow>
+                    {event.galleries.length > 0 && (
+                      <ArchiveRow label="Sústredenie" indented>
+                        {event.galleries.map((gallery) => (
+                          <GalleryButton key={gallery.id} gallery={gallery} />
+                        ))}
+                      </ArchiveRow>
+                    )}
+                  </Stack>
+                )
+              })}
             </Stack>
           </AccordionDetails>
         </Accordion>

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -1,7 +1,24 @@
-import {ExpandMore} from '@mui/icons-material'
-import {Accordion, AccordionDetails, AccordionSummary, Stack, SxProps, Theme, Typography} from '@mui/material'
+import {
+  AssignmentOutlined,
+  AssignmentTurnedInOutlined,
+  EmojiEventsOutlined,
+  ExpandMore,
+  MenuBookOutlined,
+  PhotoLibraryOutlined,
+} from '@mui/icons-material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Stack,
+  SvgIconProps,
+  SxProps,
+  Theme,
+  Typography,
+} from '@mui/material'
 import {useQuery} from '@tanstack/react-query'
-import {FC} from 'react'
+import {ComponentType, FC} from 'react'
 
 import {apiAxios} from '@/api/apiAxios'
 import {colors} from '@/theme/colors'
@@ -63,21 +80,41 @@ const getArchiveButtonSx = (disabled = false): SxProps<Theme> => {
   }
 }
 
+type ButtonKind = 'magazine' | 'results' | 'problems' | 'solutions' | 'photos'
+
+const buttonConfig: Record<ButtonKind, {label: string; Icon?: ComponentType<SvgIconProps>}> = {
+  magazine: {label: 'Časopis', Icon: MenuBookOutlined},
+  results: {label: 'Poradie', Icon: EmojiEventsOutlined},
+  problems: {label: 'Zadania', Icon: AssignmentOutlined},
+  solutions: {label: 'Riešenia', Icon: AssignmentTurnedInOutlined},
+  photos: {label: 'Fotky', Icon: PhotoLibraryOutlined},
+}
+
+const ButtonContent: FC<{kind: ButtonKind}> = ({kind}) => {
+  const {label, Icon} = buttonConfig[kind]
+  return (
+    <Box component="span" sx={{display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
+      {Icon && <Icon aria-hidden sx={{fontSize: '1em'}} />}
+      {label}
+    </Box>
+  )
+}
+
 const ArchiveActionButton: FC<{
   href: string
-  label: string
-}> = ({href, label}) => {
+  kind: ButtonKind
+}> = ({href, kind}) => {
   return (
     <Link variant="button2" href={href} sx={getArchiveButtonSx()}>
-      {label}
+      <ButtonContent kind={kind} />
     </Link>
   )
 }
 
 const PublicationButton: FC<{
   publication?: Publication
-  label?: string
-}> = ({publication, label}) => {
+  kind: ButtonKind
+}> = ({publication, kind}) => {
   return (
     <Link
       variant="button2"
@@ -85,7 +122,7 @@ const PublicationButton: FC<{
       href={publication?.file || '#'}
       sx={getArchiveButtonSx(!publication)}
     >
-      {label ?? publication?.name}
+      <ButtonContent kind={kind} />
     </Link>
   )
 }
@@ -193,20 +230,20 @@ export const Archive: FC = () => {
                 return (
                   <Stack key={event.id} gap={0}>
                     <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
-                      {seasonLeaflet && <PublicationButton publication={seasonLeaflet} label="Časopis" />}
-                      <ArchiveActionButton href={getResultsUrl(event.year, event.season_code)} label="Poradie" />
+                      {seasonLeaflet && <PublicationButton publication={seasonLeaflet} kind="magazine" />}
+                      <ArchiveActionButton href={getResultsUrl(event.year, event.season_code)} kind="results" />
                     </ArchiveRow>
                     <ArchiveRow label="1. séria" indented>
-                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 1)} label="Zadania" />
-                      <PublicationButton publication={firstSeriesLeaflet} label="Riešenia" />
+                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 1)} kind="problems" />
+                      <PublicationButton publication={firstSeriesLeaflet} kind="solutions" />
                     </ArchiveRow>
                     <ArchiveRow label="2. séria" indented>
-                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 2)} label="Zadania" />
-                      <PublicationButton publication={secondSeriesLeaflet} label="Riešenia" />
+                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 2)} kind="problems" />
+                      <PublicationButton publication={secondSeriesLeaflet} kind="solutions" />
                     </ArchiveRow>
                     {firstGallery && (
                       <ArchiveRow label="Sústredenie" indented>
-                        <ArchiveActionButton href={firstGallery.gallery_link} label="Fotky" />
+                        <ArchiveActionButton href={firstGallery.gallery_link} kind="photos" />
                       </ArchiveRow>
                     )}
                   </Stack>

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -114,6 +114,9 @@ const PublicationButton: FC<{
   )
 }
 
+// BE convention: LEAFLET (id=4) is overloaded — order=1 is the season magazine ("Časopis"),
+// order=2 is solutions of series 1 and order=3 is solutions of series 2. PublicationTypes.SOLUTIONS
+// exists in the schema but is intentionally unused here.
 const getLeafletPublication = (event: Event, order: number) => {
   return event.publication_set.find(
     (publication) => publication.publication_type === PublicationTypes.LEAFLET.id && publication.order === order,
@@ -217,7 +220,8 @@ export const Archive: FC = () => {
                 const firstGallery = event.galleries[0]
 
                 return (
-                  <Stack key={event.id} gap={0}>
+                  <Stack key={event.id}>
+                    {/* 7px keeps season-row buttons aligned with the series rows below */}
                     <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
                       {seasonLeaflet && <PublicationButton publication={seasonLeaflet} kind="magazine" />}
                       <ArchiveActionButton href={getResultsUrl(group.year, event.season_code)} kind="results" />

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -22,29 +22,16 @@ import {ComponentType, FC} from 'react'
 
 import {apiAxios} from '@/api/apiAxios'
 import {colors} from '@/theme/colors'
-import {Gallery} from '@/types/api/cms'
 import {Event, Publication, PublicationTypes} from '@/types/api/competition'
 import {useSeminarInfo} from '@/utils/useSeminarInfo'
 
 import {Link} from '../Clickable/Link'
 import {Loading} from '../Loading/Loading'
 
-// TODO: check whether we can safely assume presence of these and either update it on BE so it gets generated that way, or update it in our `types/api/competition`
-type MyPublication = Publication & {
-  name: string
-}
-
-type MyEvent = Omit<Event, 'publication_set'> & {
-  year: number
-  school_year: string
-  publication_set: MyPublication[]
-  galleries: Gallery[]
-}
-
 type YearGroup = {
   year: number
   schoolYear: string | null
-  events: MyEvent[]
+  events: Event[]
 }
 
 const getSeasonSlug = (eventSeason: number) => {
@@ -127,16 +114,18 @@ const PublicationButton: FC<{
   )
 }
 
-const getLeafletPublication = (event: MyEvent, order: number) => {
+const getLeafletPublication = (event: Event, order: number) => {
   return event.publication_set.find(
     (publication) => publication.publication_type === PublicationTypes.LEAFLET.id && publication.order === order,
   )
 }
 
-const getYearGroups = (eventList: MyEvent[]): YearGroup[] => {
+const getYearGroups = (eventList: Event[]): YearGroup[] => {
   const groups = new Map<number, YearGroup>()
 
   for (const event of eventList) {
+    if (event.year === null) continue
+
     const existingGroup = groups.get(event.year)
 
     if (existingGroup) {
@@ -195,7 +184,7 @@ export const Archive: FC = () => {
 
   const {data: eventListData, isLoading: eventListIsLoading} = useQuery({
     queryKey: ['competition', 'event', `competition=${seminarId}`],
-    queryFn: () => apiAxios.get<MyEvent[]>(`/competition/event/?competition=${seminarId}`),
+    queryFn: () => apiAxios.get<Event[]>(`/competition/event/?competition=${seminarId}`),
   })
   const eventList = eventListData?.data ?? []
   const yearGroups = getYearGroups(eventList)
@@ -231,14 +220,14 @@ export const Archive: FC = () => {
                   <Stack key={event.id} gap={0}>
                     <ArchiveRow label={getSeasonLabel(event.season_code)} gap={'7px'}>
                       {seasonLeaflet && <PublicationButton publication={seasonLeaflet} kind="magazine" />}
-                      <ArchiveActionButton href={getResultsUrl(event.year, event.season_code)} kind="results" />
+                      <ArchiveActionButton href={getResultsUrl(group.year, event.season_code)} kind="results" />
                     </ArchiveRow>
                     <ArchiveRow label="1. séria" indented>
-                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 1)} kind="problems" />
+                      <ArchiveActionButton href={getProblemsUrl(group.year, event.season_code, 1)} kind="problems" />
                       <PublicationButton publication={firstSeriesLeaflet} kind="solutions" />
                     </ArchiveRow>
                     <ArchiveRow label="2. séria" indented>
-                      <ArchiveActionButton href={getProblemsUrl(event.year, event.season_code, 2)} kind="problems" />
+                      <ArchiveActionButton href={getProblemsUrl(group.year, event.season_code, 2)} kind="problems" />
                       <PublicationButton publication={secondSeriesLeaflet} kind="solutions" />
                     </ArchiveRow>
                     {firstGallery && (

--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -69,7 +69,7 @@ const getArchiveButtonSx = (disabled = false): SxProps<Theme> => {
 
 type ButtonKind = 'magazine' | 'results' | 'problems' | 'solutions' | 'photos'
 
-const buttonConfig: Record<ButtonKind, {label: string; Icon?: ComponentType<SvgIconProps>}> = {
+const buttonConfig: Record<ButtonKind, {label: string; Icon: ComponentType<SvgIconProps>}> = {
   magazine: {label: 'Časopis', Icon: MenuBookOutlined},
   results: {label: 'Poradie', Icon: EmojiEventsOutlined},
   problems: {label: 'Zadania', Icon: AssignmentOutlined},
@@ -81,7 +81,7 @@ const ButtonContent: FC<{kind: ButtonKind}> = ({kind}) => {
   const {label, Icon} = buttonConfig[kind]
   return (
     <Box component="span" sx={{display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
-      {Icon && <Icon aria-hidden sx={{fontSize: '1em'}} />}
+      <Icon aria-hidden sx={{fontSize: '1em'}} />
       {label}
     </Box>
   )
@@ -201,15 +201,12 @@ export const Archive: FC = () => {
           key={group.year}
           defaultExpanded={index === 0}
           disableGutters
-          square={false}
           sx={{boxShadow: 'none', '&:before': {display: 'none'}}}
         >
           <AccordionSummary expandIcon={<ExpandMore color="primary" fontSize="large" />} sx={{p: 0}}>
-            <Stack direction="row" sx={{flexGrow: 1}}>
-              <Typography variant="h2" sx={{flexGrow: 1}}>
-                {group.year + '. ročník' + (group.schoolYear ? ` \u2013 ${group.schoolYear}` : '')}
-              </Typography>
-            </Stack>
+            <Typography variant="h2" sx={{flexGrow: 1}}>
+              {group.year + '. ročník' + (group.schoolYear ? ` \u2013 ${group.schoolYear}` : '')}
+            </Typography>
           </AccordionSummary>
           <AccordionDetails sx={{p: 0}}>
             <Stack gap={1}>


### PR DESCRIPTION
Resolves #764

- Group archive entries into year accordions.
- Render season and series rows with leaflet-based Casopis/Riesenia links.
- Open the first accordion by default.
- Add archive row and action button hover behavior.

**Landing view - one unwraped + hover effect**
<img width="1289" height="654" alt="image" src="https://github.com/user-attachments/assets/17d9ae7c-8a48-4d6c-ba7a-56aa7c5bd9cd" />

**Year with Fotky**
<img width="625" height="319" alt="image" src="https://github.com/user-attachments/assets/2ea93f65-d63a-4c9f-8507-c88c4afacf9f" />

**Phone view**
<img width="376" height="606" alt="image" src="https://github.com/user-attachments/assets/ea64a30c-a9bd-474d-894c-f1d37f4f798a" />
