### PR TITLE
Disable Sentry in development

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -8,8 +8,11 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: 'https://428ff2792107c70d35d5eca360f4617a@o4510493471932416.ingest.de.sentry.io/4511236823449680',
 
+  // Don't send events to Sentry in development
+  enabled: process.env.NODE_ENV !== 'development',
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1 : 0.1,
+  tracesSampleRate: 0.1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -7,8 +7,11 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: 'https://428ff2792107c70d35d5eca360f4617a@o4510493471932416.ingest.de.sentry.io/4511236823449680',
 
+  // Don't send events to Sentry in development
+  enabled: process.env.NODE_ENV !== 'development',
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1 : 0.1,
+  tracesSampleRate: 0.1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,11 +7,14 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: 'https://428ff2792107c70d35d5eca360f4617a@o4510493471932416.ingest.de.sentry.io/4511236823449680',
 
+  // Don't send events to Sentry in development
+  enabled: process.env.NODE_ENV !== 'development',
+
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1 : 0.1,
+  tracesSampleRate: 0.1,
   // Enable logs to be sent to Sentry
   enableLogs: true,
 


### PR DESCRIPTION
## Summary
- Set `enabled: process.env.NODE_ENV !== 'development'` on all three Sentry init calls (server, edge, client) so local dev errors and traces are no longer forwarded to the cloud project.
- Simplified `tracesSampleRate` to `0.1` since the previous dev-only `1` branch is now unreachable.

## Test plan
- [ ] Run `bun run dev` and trigger an error — verify nothing appears in the Sentry project.
- [ ] Confirm production build behavior is unchanged (Sentry still initialized, sample rate `0.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)